### PR TITLE
fix: add /play/user/password/:id route for client compatibility

### DIFF
--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -66,6 +66,7 @@ func (c *Config) xtreamRoutes(r *gin.RouterGroup) {
 	r.GET(fmt.Sprintf("/hlsr/:token/%s/%s/:channel/:hash/:chunk", c.User, c.Password), c.xtreamHlsrStream)
 	r.GET("/hls/:token/:chunk", c.xtreamHlsStream)
 	r.GET("/play/:token/:type", c.xtreamStreamPlay)
+	r.GET(fmt.Sprintf("/play/%s/%s/:id", c.User, c.Password), c.xtreamStreamHandler)
 }
 
 func (c *Config) m3uRoutes(r *gin.RouterGroup) {


### PR DESCRIPTION
From ridgarou_master. Some clients expect video URLs to use `/play/user/pass/id`. Adds route `GET /play/<configured-user>/<configured-password>/:id` where the path uses the proxy's configured user and password (not arbitrary placeholders), mapped to the same handler as the existing stream routes.

Requesting review from @copilot

Made with [Cursor](https://cursor.com)