### PR TITLE
fix: apply exclusions to served M3U when settings change from UI

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2,6 +2,9 @@ package server
 
 import (
 	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jamesnetherton/m3u"
@@ -111,5 +114,124 @@ func TestChannelsProcessed_StreamURL(t *testing.T) {
 	}
 	if out[0].Excluded {
 		t.Error("channelsProcessed() channel should not be excluded")
+	}
+}
+
+// countEXTINFInFile returns the number of #EXTINF lines in an M3U file (one per track).
+func countEXTINFInFile(path string) (int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	n := 0
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#EXTINF:") {
+			n++
+		}
+	}
+	return n, nil
+}
+
+// TestApplyLiveSettings_RestoresFullPlaylistBeforeFiltering verifies that when the user changes
+// exclusions in the UI and saves, the served M3U is rebuilt from the full playlist, not from
+// the previously filtered subset. Otherwise removing an exclusion would never bring back tracks.
+func TestApplyLiveSettings_RestoresFullPlaylistBeforeFiltering(t *testing.T) {
+	dir := t.TempDir()
+	m3uPath := filepath.Join(dir, "out.m3u")
+
+	track1 := m3u.Track{Name: "Ch1", URI: "http://example.com/1", Length: 0, Tags: []m3u.Tag{{Name: "group-title", Value: "Group1"}}}
+	track2 := m3u.Track{Name: "Ch2", URI: "http://example.com/2", Length: 0, Tags: []m3u.Tag{{Name: "group-title", Value: "Group2"}}}
+	track3 := m3u.Track{Name: "Ch3", URI: "http://example.com/3", Length: 0, Tags: []m3u.Tag{{Name: "group-title", Value: "Group3"}}}
+	fullTracks := []m3u.Track{track1, track2, track3}
+	playlist := &m3u.Playlist{Tracks: make([]m3u.Track, len(fullTracks))}
+	copy(playlist.Tracks, fullTracks)
+
+	c := &Config{
+		ProxyConfig: &config.ProxyConfig{
+			HostConfig:    &config.HostConfiguration{Hostname: "localhost", Port: 8080},
+			AdvertisedPort: 8080,
+			User:          config.CredentialString("u"),
+			Password:      config.CredentialString("p"),
+		},
+		playlist:           playlist,
+		fullPlaylistTracks: fullTracks,
+		proxyfiedM3UPath:   m3uPath,
+		endpointAntiColision: "x",
+	}
+
+	// First run: apply exclusion for Group2 -> served M3U should have 2 tracks.
+	c.ProxyConfig.GroupExclusions = []string{`^Group2$`}
+	if err := c.playlistInitialization(); err != nil {
+		t.Fatalf("playlistInitialization(): %v", err)
+	}
+	if len(c.playlist.Tracks) != 2 {
+		t.Errorf("after first init with exclusion: len(playlist.Tracks) = %d, want 2", len(c.playlist.Tracks))
+	}
+	count, err := countEXTINFInFile(m3uPath)
+	if err != nil {
+		t.Fatalf("countEXTINFInFile(): %v", err)
+	}
+	if count != 2 {
+		t.Errorf("after first init: track count in file = %d, want 2", count)
+	}
+
+	// Apply new settings with no exclusions (user removed the exclusion in UI). Without restoring
+	// fullPlaylistTracks, we would filter from the current 2-track list and never get the third back.
+	settingsNoExcl := &config.SettingsJSON{GroupExclusions: []string{}}
+	c.applyLiveSettings(settingsNoExcl)
+
+	if len(c.playlist.Tracks) != 3 {
+		t.Errorf("after applyLiveSettings(no exclusions): len(playlist.Tracks) = %d, want 3 (full list)", len(c.playlist.Tracks))
+	}
+	count, err = countEXTINFInFile(m3uPath)
+	if err != nil {
+		t.Fatalf("countEXTINFInFile(): %v", err)
+	}
+	if count != 3 {
+		t.Errorf("after applyLiveSettings(no exclusions): track count in file = %d, want 3 (served M3U must include all)", count)
+	}
+}
+
+// TestMarshallInto_GroupExclusionReducesTracks verifies that group exclusions are applied when
+// writing the M3U so the file served to clients contains only non-excluded tracks.
+func TestMarshallInto_GroupExclusionReducesTracks(t *testing.T) {
+	dir := t.TempDir()
+	m3uPath := filepath.Join(dir, "out.m3u")
+	f, err := os.Create(m3uPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	track1 := m3u.Track{Name: "A", URI: "http://ex.com/1", Length: 0, Tags: []m3u.Tag{{Name: "group-title", Value: "Sports"}}}
+	track2 := m3u.Track{Name: "B", URI: "http://ex.com/2", Length: 0, Tags: []m3u.Tag{{Name: "group-title", Value: "News"}}}
+	track3 := m3u.Track{Name: "C", URI: "http://ex.com/3", Length: 0, Tags: []m3u.Tag{{Name: "group-title", Value: "Sports"}}}
+	tracks := []m3u.Track{track1, track2, track3}
+	playlist := &m3u.Playlist{Tracks: tracks}
+
+	c := &Config{
+		ProxyConfig: &config.ProxyConfig{
+			HostConfig:    &config.HostConfiguration{Hostname: "localhost", Port: 8080},
+			AdvertisedPort: 8080,
+			User:          config.CredentialString("u"),
+			Password:      config.CredentialString("p"),
+			GroupExclusions: []string{`^News$`},
+		},
+		playlist:           playlist,
+		endpointAntiColision: "x",
+	}
+	if err := c.marshallInto(f, false); err != nil {
+		t.Fatalf("marshallInto(): %v", err)
+	}
+	// Sync so file is readable
+	_ = f.Sync()
+	f.Close()
+
+	count, err := countEXTINFInFile(m3uPath)
+	if err != nil {
+		t.Fatalf("countEXTINFInFile(): %v", err)
+	}
+	if count != 2 {
+		t.Errorf("track count in file = %d, want 2 (News excluded)", count)
 	}
 }

--- a/pkg/server/ui.go
+++ b/pkg/server/ui.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/jamesnetherton/m3u"
 
 	"github.com/alvarolobato/iptv-proxy/pkg/config"
 )
@@ -70,6 +71,7 @@ func (c *Config) runUIServer() {
 	router.GET("/api/replacements", func(ctx *gin.Context) {
 		data, err := c.readReplacementsFile()
 		if err != nil {
+			log.Printf("[iptv-proxy] GET /api/replacements: %v", err)
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
@@ -84,6 +86,7 @@ func (c *Config) runUIServer() {
 			return
 		}
 		if err := c.writeReplacementsFile(&raw); err != nil {
+			log.Printf("[iptv-proxy] PUT /api/replacements: %v", err)
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
@@ -95,6 +98,7 @@ func (c *Config) runUIServer() {
 	router.GET("/api/settings", func(ctx *gin.Context) {
 		file, err := c.readSettingsFileStruct()
 		if err != nil {
+			log.Printf("[iptv-proxy] GET /api/settings: %v", err)
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
@@ -112,6 +116,7 @@ func (c *Config) runUIServer() {
 			return
 		}
 		if err := c.writeSettingsFile(&s); err != nil {
+			log.Printf("[iptv-proxy] PUT /api/settings: %v", err)
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
@@ -363,6 +368,8 @@ func (c *Config) writeSettingsFile(s *config.SettingsJSON) error {
 
 // applyLiveSettings applies filter lists and replacements from s to the running config and regenerates the proxyfied M3U.
 // Only safe-to-reload-at-runtime fields are applied (inclusions, exclusions, replacements); port/hostname etc. are unchanged.
+// We restore the full playlist from fullPlaylistTracks before re-filtering so that the served M3U always reflects the
+// current inclusion/exclusion rules applied to the full source list (not to a previously filtered subset).
 func (c *Config) applyLiveSettings(s *config.SettingsJSON) {
 	if s == nil {
 		return
@@ -381,6 +388,11 @@ func (c *Config) applyLiveSettings(s *config.SettingsJSON) {
 		}
 	}
 	c.settings = &sCopy
+	// Restore full playlist so marshallInto applies current filters to the full list (not to already-filtered tracks).
+	if len(c.fullPlaylistTracks) > 0 {
+		c.playlist.Tracks = make([]m3u.Track, len(c.fullPlaylistTracks))
+		copy(c.playlist.Tracks, c.fullPlaylistTracks)
+	}
 	if err := c.playlistInitialization(); err != nil {
 		log.Printf("[iptv-proxy] applyLiveSettings: playlistInitialization: %v", err)
 	}

--- a/web/frontend/e2e/app.spec.js
+++ b/web/frontend/e2e/app.spec.js
@@ -194,6 +194,17 @@ test.describe('Data & processing', () => {
     expect(withIncluded.length).toBeGreaterThanOrEqual(1);
   });
 
+  test('Downloaded M3U has exclusions applied (devices get filtered list)', async ({ request }) => {
+    // E2E testdata has group_exclusions: ["^Group2$"]. Fixture test.m3u has 2 tracks: Group1, Group2.
+    // So the served M3U must have 1 track (Group2 excluded).
+    const m3uUrl = 'http://localhost:18080/iptv.m3u?username=usertest&password=passwordtest';
+    const res = await request.get(m3uUrl);
+    expect(res.ok()).toBeTruthy();
+    const body = await res.text();
+    const extinfCount = (body.match(/^#EXTINF:/gm) || []).length;
+    expect(extinfCount).toBe(1);
+  });
+
   test('Screenshot: Groups tab shows both Included and Excluded with Status column', async ({ page }) => {
     await page.goto('/');
     await page.getByRole('tab', { name: 'Groups' }).click();


### PR DESCRIPTION
## Problem
Exclusions worked in the UI (groups/channels showed Included/Excluded), but when devices downloaded the M3U playlist they received all channels and groups — exclusions were not applied to the actual file served to clients.

## Cause
`applyLiveSettings` updated `GroupExclusions` etc. and called `playlistInitialization()` → `marshallInto()`, but `marshallInto` filters from `c.playlist.Tracks`, which had already been replaced by a *previously* filtered list. So we were re-filtering an already-reduced set: removing an exclusion could never bring tracks back, and the served file was out of sync with current settings.

## Fix
Before calling `playlistInitialization()` in `applyLiveSettings`, restore the full playlist from `fullPlaylistTracks` so `marshallInto` always applies the current inclusion/exclusion rules to the full source list.

## Tests
- **Unit:** `TestApplyLiveSettings_RestoresFullPlaylistBeforeFiltering` — apply exclusion then clear it; served M3U must have all tracks again.
- **Unit:** `TestMarshallInto_GroupExclusionReducesTracks` — group exclusion reduces track count in written file.
- **E2E:** "Downloaded M3U has exclusions applied (devices get filtered list)" — GET the M3U and assert `#EXTINF` count matches exclusions (e2e testdata has `^Group2$` excluded → 1 track).

Made with [Cursor](https://cursor.com)