### PR TITLE
Remove committed settings.json and add to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ iptv/iptv.m3u
 # Local env (credentials / m3u URL). Use .env.example as template; CI can use secrets.
 .env
 
+# Runtime settings file — may contain m3u_url, passwords, and other credentials written by the UI.
+# The app creates this automatically on first run (EnsureStubSettings). Never commit real instances.
+data/settings.json
+
 # E2E evidence output (screenshot + API dump)
 web/frontend/e2e/evidence/
 

--- a/data/settings.json
+++ b/data/settings.json
@@ -1,3 +1,0 @@
-{
-  "replacements": {}
-}


### PR DESCRIPTION
## Summary
This PR removes the `data/settings.json` file from version control and adds it to `.gitignore` to prevent credentials and sensitive configuration from being accidentally committed.

## Key Changes
- Removed `data/settings.json` from the repository (it was previously committed with a stub configuration)
- Added `data/settings.json` to `.gitignore` with documentation explaining that this file:
  - Contains runtime settings including m3u_url, passwords, and other credentials
  - Is automatically generated by the app on first run (via `EnsureStubSettings`)
  - Should never have real instances committed to version control

## Details
The settings file is dynamically created by the application at runtime and may contain sensitive information written by the UI. By removing it from version control and adding it to gitignore, we ensure that user credentials and configuration are not accidentally exposed in the repository history.

https://claude.ai/code/session_01Tm4XTFvFTWy7SX8pwwoFdn