### PR TITLE
feat: Kibana dashboard tooling module (issue #34)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,14 @@ This file gives AI agents and future sessions application context and where to f
 
 **UI framework:** The configuration UI uses [Elastic UI (EUI)](https://eui.elastic.co/docs/components/). Refer to the [EUI component docs](https://eui.elastic.co/docs/components/) for patterns (tables, filter groups, buttons, etc.).
 
+## Module agents
+
+When working in a specific module, load the module's own agent context in addition to this file:
+
+| Working in | Load also |
+|---|---|
+| `dashboards/` | [`dashboards/AGENTS.md`](dashboards/AGENTS.md) — Kibana dashboard expert: YAML format, ES\|QL patterns, compile/upload workflow, IPTV data model |
+
 ---
 
 ## What the application does

--- a/dashboards/AGENTS.md
+++ b/dashboards/AGENTS.md
@@ -1,0 +1,97 @@
+# Dashboard Expert Agent
+
+You are a Kibana dashboard expert. Load the skill files below when working in this directory or when asked to create, modify, or review Kibana dashboards.
+
+## Activation
+
+Activate when:
+- Working in the `dashboards/` directory
+- Asked to create, edit, or review a Kibana dashboard
+- Asked about ES|QL queries for IPTV data
+- Asked to compile, lint, upload, or screenshot dashboards
+
+## Skills — load before working
+
+Read these files into context at the start of a dashboard task:
+
+| File | When to load |
+|---|---|
+| `dashboards/skills/iptv-data-model.md` | Always — IPTV index schemas and field reference |
+| `dashboards/skills/kibana-dashboard-yaml.md` | Always — YAML format spec and compilation guide |
+| `dashboards/skills/kb-dashboard-cli-usage.md` | When compiling, uploading, or screenshotting |
+| `dashboards/skills/esql-language-reference.md` | When writing ES|QL queries |
+| `dashboards/skills/esql-query-patterns.md` | When translating natural language to ES|QL |
+| `dashboards/skills/kibana-dashboard-style-guide.md` | When designing layout and visualization choices |
+
+## Dashboard workflow
+
+### Write or edit a dashboard
+
+1. Edit a YAML file in `dashboards/definitions/`
+2. Validate it compiles: `uvx kb-dashboard-cli compile --input-file dashboards/definitions/<file>.yaml`
+3. Optionally lint: `uvx kb-dashboard-lint check --input-file dashboards/definitions/<file>.yaml`
+4. Upload for review: `uvx kb-dashboard-cli compile --input-file dashboards/definitions/<file>.yaml --upload`
+
+### Upload to Kibana
+
+```bash
+# Environment variables (preferred)
+export KIBANA_URL=https://your-kibana:5601
+export KIBANA_API_KEY=your-base64-api-key
+uvx kb-dashboard-cli compile --input-file dashboards/definitions/<file>.yaml --upload
+
+# Or with username/password
+uvx kb-dashboard-cli compile --input-file dashboards/definitions/<file>.yaml \
+  --upload --kibana-url $KIBANA_URL --kibana-username elastic --kibana-password $KIBANA_PASSWORD
+```
+
+### Screenshot a dashboard
+
+```bash
+uvx kb-dashboard-cli screenshot \
+  --dashboard-id <id> \
+  --output dashboards/screenshots/<name>.png \
+  --kibana-url $KIBANA_URL --kibana-api-key $KIBANA_API_KEY
+```
+
+### Decompile an existing Kibana dashboard to YAML
+
+```bash
+uvx kb-dashboard-cli fetch <dashboard-url-or-id> --output /tmp/dashboard.ndjson
+uvx kb-dashboard-cli disassemble /tmp/dashboard.ndjson -o /tmp/disassembled/
+# Then convert panels in /tmp/disassembled/ to YAML manually
+```
+
+## IPTV data conventions
+
+### Index prefix
+
+Default: `iptv`. If `--es-index-prefix` was used at startup, substitute that prefix:
+- `iptv.sessions` → `{prefix}.sessions`
+- `iptv.user_history` → `{prefix}.user_history`
+- `metrics-iptv.channel_metrics` → `metrics-{prefix}.channel_metrics`
+
+### Choosing the right index
+
+- **Active/real-time session counts** → `{prefix}.sessions` filtered to `event_kind == "session_start"` within last 5 min
+- **User leaderboards, history** → `{prefix}.user_history` (one doc per completed session)
+- **Channel trends, bandwidth over time** → `metrics-{prefix}.channel_metrics` (TSDB aggregates)
+- **Error analysis** → `{prefix}.sessions` where `event_kind == "session_error"`
+
+### ES|QL best practices for IPTV data
+
+1. Always use dynamic time bucketing: `BUCKET(@timestamp, 20, ?_tstart, ?_tend)`
+2. Filter indexed fields immediately after `FROM` for performance
+3. Use `user_name` (keyword) for user filters — exact case-sensitive match
+4. `channel_metrics` is TSDB — use `TS` source and `RATE()` for counter fields on ES 9.2+; use `FROM` + `MAX()` on Kibana 8.x
+5. `duration_seconds` and `bytes_transferred` in `user_history` are per-session totals (not cumulative)
+
+## Updating skills
+
+Skills in `dashboards/skills/` (except `iptv-data-model.md`) are synced from upstream:
+
+```bash
+bash dashboards/scripts/sync-skills.sh
+```
+
+This pulls the latest curated docs from `alvarolobato/grafana-import-cli`. The IPTV data model is maintained locally and is never overwritten.

--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -1,0 +1,100 @@
+# IPTV-Proxy Kibana Dashboards
+
+YAML-based Kibana dashboard definitions for iptv-proxy2 analytics. Dashboards are compiled to Kibana NDJSON using [`kb-yaml-to-lens`](https://github.com/strawgate/kb-yaml-to-lens).
+
+## Quick start
+
+```bash
+# Compile a dashboard to NDJSON (dry run, no upload)
+uvx kb-dashboard-cli compile --input-file dashboards/definitions/user-dashboard.yaml
+
+# Compile and upload to Kibana
+export KIBANA_URL=https://your-kibana:5601
+export KIBANA_API_KEY=your-base64-api-key
+uvx kb-dashboard-cli compile --input-file dashboards/definitions/user-dashboard.yaml --upload
+
+# Lint for best practices
+uvx kb-dashboard-lint check --input-file dashboards/definitions/user-dashboard.yaml
+```
+
+## Prerequisites
+
+- Python 3.12+ with `uv`/`uvx` — see [uv docs](https://github.com/astral-sh/uv)
+- Kibana 8.x or 9.x (for upload/screenshot)
+- iptv-proxy2 running with `--es-url` configured (to have data)
+
+## Folder structure
+
+```
+dashboards/
+├── AGENTS.md                       # Dashboard expert agent instructions
+├── README.md                       # This file
+├── scripts/
+│   └── sync-skills.sh              # Pull updated docs from upstream
+├── skills/                         # Reference docs for AI agents
+│   ├── iptv-data-model.md          # IPTV index schemas (maintained here)
+│   ├── kibana-dashboard-yaml.md    # YAML format spec (synced from upstream)
+│   ├── esql-language-reference.md  # ES|QL reference (synced from upstream)
+│   ├── esql-query-patterns.md      # Query patterns (synced from upstream)
+│   ├── kibana-dashboard-style-guide.md  # Layout guide (synced from upstream)
+│   └── kb-dashboard-cli-usage.md   # CLI reference (synced from upstream)
+└── definitions/
+    ├── user-dashboard.yaml         # User leaderboard and activity dashboard
+    └── channel-dashboard.yaml      # Channel metrics dashboard
+```
+
+## Available dashboards
+
+### User Dashboard (`definitions/user-dashboard.yaml`)
+
+Analytics focused on user activity:
+- Active sessions (real-time count)
+- Total unique users
+- User leaderboard (top watchers by hours)
+- User activity over time (stacked area)
+- Recent sessions table
+- Per-user channel preferences
+
+**Data source:** `iptv.sessions`, `iptv.user_history`
+
+### Channel Dashboard (`definitions/channel-dashboard.yaml`)
+
+Channel performance metrics:
+- Top channels by watch time
+- Channel activity timeline
+- Group distribution (pie)
+- Error rate metric
+- Bandwidth usage over time
+
+**Data source:** `metrics-iptv.channel_metrics`, `iptv.sessions`
+
+## Environment variables
+
+```bash
+export KIBANA_URL=https://your-kibana:5601
+
+# API key (recommended)
+export KIBANA_API_KEY=your-base64-api-key
+
+# Or basic auth
+export KIBANA_USERNAME=elastic
+export KIBANA_PASSWORD=changeme
+
+# Optional: target a specific Kibana space
+export KIBANA_SPACE_ID=iptv
+```
+
+## Updating skill documentation
+
+Skills in `dashboards/skills/` (except `iptv-data-model.md`) are sourced from [`alvarolobato/grafana-import-cli`](https://github.com/alvarolobato/grafana-import-cli). To pull the latest:
+
+```bash
+bash dashboards/scripts/sync-skills.sh
+```
+
+## Related
+
+- Issue [#34](https://github.com/alvarolobato/iptv-proxy/issues/34) — Dashboard tooling epic
+- Issue [#31](https://github.com/alvarolobato/iptv-proxy/issues/31) — Multi-user epic
+- [`strawgate/kb-yaml-to-lens`](https://github.com/strawgate/kb-yaml-to-lens) — Dashboard compiler
+- [`alvarolobato/grafana-import-cli`](https://github.com/alvarolobato/grafana-import-cli) — Skills source

--- a/dashboards/definitions/channel-dashboard.yaml
+++ b/dashboards/definitions/channel-dashboard.yaml
@@ -1,0 +1,162 @@
+dashboards:
+  - name: "[IPTV] Channel Metrics"
+    description: >
+      Channel performance metrics: concurrent viewers, bandwidth, errors, and group distribution.
+      Data sources: metrics-iptv.channel_metrics, iptv.sessions.
+    time_range: last_24_hours
+    settings:
+      sync_cursor: true
+
+    panels:
+      # ── Summary metrics ────────────────────────────────────────────────────
+      - title: Peak Concurrent Viewers
+        size: {w: 12, h: 8}
+        esql:
+          type: metric
+          query: |
+            FROM metrics-iptv.channel_metrics
+            | WHERE @timestamp >= ?_tstart AND @timestamp <= ?_tend
+            | STATS peak_viewers = MAX(active_sessions)
+          primary:
+            field: peak_viewers
+            label: Peak Concurrent
+
+      - title: Total Channels Watched
+        size: {w: 12, h: 8}
+        esql:
+          type: metric
+          query: |
+            FROM metrics-iptv.channel_metrics
+            | WHERE @timestamp >= ?_tstart AND @timestamp <= ?_tend
+            | WHERE session_count > 0
+            | STATS channels_active = COUNT_DISTINCT(channel_id)
+          primary:
+            field: channels_active
+            label: Active Channels
+
+      - title: Total Bandwidth
+        size: {w: 12, h: 8}
+        esql:
+          type: metric
+          query: |
+            FROM metrics-iptv.channel_metrics
+            | WHERE @timestamp >= ?_tstart AND @timestamp <= ?_tend
+            | STATS total_gb = ROUND(SUM(bytes_transferred) / 1073741824.0, 1)
+          primary:
+            field: total_gb
+            label: Total GB
+
+      - title: Stream Errors
+        size: {w: 12, h: 8}
+        esql:
+          type: metric
+          query: |
+            FROM iptv.sessions
+            | WHERE @timestamp >= ?_tstart AND @timestamp <= ?_tend AND event_kind == "session_error"
+            | STATS errors = COUNT(*)
+          primary:
+            field: errors
+            label: Errors
+
+      # ── Active sessions timeline ───────────────────────────────────────────
+      - title: Concurrent Viewers Over Time
+        size: {w: 48, h: 15}
+        esql:
+          type: line
+          query: |
+            FROM metrics-iptv.channel_metrics
+            | WHERE @timestamp >= ?_tstart AND @timestamp <= ?_tend
+            | STATS viewers = MAX(active_sessions) BY
+                time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend),
+                channel_name
+            | SORT time_bucket ASC
+          x_field: time_bucket
+          y_field: viewers
+          breakdown_field: channel_name
+
+      # ── Top channels ──────────────────────────────────────────────────────
+      - title: Top Channels by Watch Time
+        size: {w: 48, h: 20}
+        esql:
+          type: datatable
+          query: |
+            FROM metrics-iptv.channel_metrics
+            | WHERE @timestamp >= ?_tstart AND @timestamp <= ?_tend
+            | STATS
+                total_sessions = SUM(session_count),
+                peak_viewers = MAX(active_sessions),
+                total_hours = ROUND(SUM(total_duration_seconds) / 3600.0, 1),
+                total_gb = ROUND(SUM(bytes_transferred) / 1073741824.0, 2),
+                errors = SUM(error_count)
+              BY channel_name, channel_group, channel_type
+            | SORT total_hours DESC
+            | LIMIT 50
+          columns:
+            - field: channel_name
+              label: Channel
+            - field: channel_group
+              label: Group
+            - field: channel_type
+              label: Type
+            - field: total_sessions
+              label: Sessions
+            - field: peak_viewers
+              label: Peak Viewers
+            - field: total_hours
+              label: Watch Hours
+            - field: total_gb
+              label: Bandwidth (GB)
+            - field: errors
+              label: Errors
+
+      # ── Group distribution ────────────────────────────────────────────────
+      - title: Watch Time by Group
+        size: {w: 24, h: 15}
+        esql:
+          type: pie
+          query: |
+            FROM metrics-iptv.channel_metrics
+            | WHERE @timestamp >= ?_tstart AND @timestamp <= ?_tend
+            | STATS watch_hours = ROUND(SUM(total_duration_seconds) / 3600.0, 1) BY channel_group
+            | SORT watch_hours DESC
+            | LIMIT 10
+          breakdown_field: channel_group
+          metric_field: watch_hours
+
+      - title: Watch Time by Channel Type
+        size: {w: 24, h: 15}
+        esql:
+          type: pie
+          query: |
+            FROM metrics-iptv.channel_metrics
+            | WHERE @timestamp >= ?_tstart AND @timestamp <= ?_tend
+            | STATS watch_hours = ROUND(SUM(total_duration_seconds) / 3600.0, 1) BY channel_type
+            | SORT watch_hours DESC
+          breakdown_field: channel_type
+          metric_field: watch_hours
+
+      # ── Bandwidth over time ───────────────────────────────────────────────
+      - title: Bandwidth Over Time (GB)
+        size: {w: 48, h: 15}
+        esql:
+          type: area
+          query: |
+            FROM metrics-iptv.channel_metrics
+            | WHERE @timestamp >= ?_tstart AND @timestamp <= ?_tend
+            | STATS bandwidth_gb = ROUND(SUM(bytes_transferred) / 1073741824.0, 3) BY
+                time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend),
+                channel_group
+            | SORT time_bucket ASC
+          x_field: time_bucket
+          y_field: bandwidth_gb
+          breakdown_field: channel_group
+
+    controls:
+      - type: options
+        label: Channel Group
+        data_view: metrics-iptv.channel_metrics
+        field: channel_group
+      - type: options
+        label: Channel Type
+        data_view: metrics-iptv.channel_metrics
+        field: channel_type

--- a/dashboards/definitions/user-dashboard.yaml
+++ b/dashboards/definitions/user-dashboard.yaml
@@ -1,0 +1,164 @@
+dashboards:
+  - name: "[IPTV] User Activity"
+    description: >
+      User leaderboard, per-user activity, and session history for iptv-proxy2.
+      Data sources: iptv.sessions, iptv.user_history.
+    time_range: last_30_days
+    settings:
+      sync_cursor: true
+
+    panels:
+      # ── Summary metrics ────────────────────────────────────────────────────
+      - title: Active Sessions
+        size: {w: 12, h: 8}
+        esql:
+          type: metric
+          query: |
+            FROM iptv.sessions
+            | WHERE @timestamp > NOW() - 5 minutes AND event_kind == "session_start"
+            | STATS active_sessions = COUNT(DISTINCT session_id)
+          primary:
+            field: active_sessions
+            label: Active Sessions
+
+      - title: Total Users
+        size: {w: 12, h: 8}
+        esql:
+          type: metric
+          query: |
+            FROM iptv.user_history
+            | WHERE @timestamp >= ?_tstart AND @timestamp <= ?_tend
+            | STATS total_users = COUNT_DISTINCT(user_name)
+          primary:
+            field: total_users
+            label: Unique Users
+
+      - title: Total Sessions
+        size: {w: 12, h: 8}
+        esql:
+          type: metric
+          query: |
+            FROM iptv.user_history
+            | WHERE @timestamp >= ?_tstart AND @timestamp <= ?_tend
+            | STATS total_sessions = COUNT(*)
+          primary:
+            field: total_sessions
+            label: Sessions
+
+      - title: Total Watch Time
+        size: {w: 12, h: 8}
+        esql:
+          type: metric
+          query: |
+            FROM iptv.user_history
+            | WHERE @timestamp >= ?_tstart AND @timestamp <= ?_tend
+            | STATS watch_hours = ROUND(SUM(duration_seconds) / 3600.0, 0)
+          primary:
+            field: watch_hours
+            label: Watch Hours
+
+      # ── User activity over time ────────────────────────────────────────────
+      - title: Session Starts Over Time
+        size: {w: 48, h: 15}
+        esql:
+          type: area
+          query: |
+            FROM iptv.sessions
+            | WHERE @timestamp >= ?_tstart AND @timestamp <= ?_tend AND event_kind == "session_start"
+            | STATS sessions = COUNT(*) BY
+                time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend),
+                user_name
+            | SORT time_bucket ASC
+          x_field: time_bucket
+          y_field: sessions
+          breakdown_field: user_name
+
+      # ── User leaderboard ──────────────────────────────────────────────────
+      - title: User Leaderboard
+        size: {w: 48, h: 20}
+        esql:
+          type: datatable
+          query: |
+            FROM iptv.user_history
+            | WHERE @timestamp >= ?_tstart AND @timestamp <= ?_tend
+            | STATS
+                sessions = COUNT(*),
+                total_hours = ROUND(SUM(duration_seconds) / 3600.0, 2),
+                total_gb = ROUND(SUM(bytes_transferred) / 1073741824.0, 3),
+                unique_channels = COUNT_DISTINCT(channel_id)
+              BY user_name
+            | SORT total_hours DESC
+            | LIMIT 50
+          columns:
+            - field: user_name
+              label: User
+            - field: sessions
+              label: Sessions
+            - field: total_hours
+              label: Watch Hours
+            - field: total_gb
+              label: Data (GB)
+            - field: unique_channels
+              label: Unique Channels
+
+      # ── Channel preferences ───────────────────────────────────────────────
+      - title: Top Channels by Watch Time
+        size: {w: 24, h: 15}
+        esql:
+          type: bar
+          query: |
+            FROM iptv.user_history
+            | WHERE @timestamp >= ?_tstart AND @timestamp <= ?_tend
+            | STATS watch_hours = ROUND(SUM(duration_seconds) / 3600.0, 1) BY channel_name
+            | SORT watch_hours DESC
+            | LIMIT 15
+          x_field: channel_name
+          y_field: watch_hours
+
+      - title: Watch Time by Channel Group
+        size: {w: 24, h: 15}
+        esql:
+          type: pie
+          query: |
+            FROM iptv.user_history
+            | WHERE @timestamp >= ?_tstart AND @timestamp <= ?_tend
+            | STATS watch_hours = ROUND(SUM(duration_seconds) / 3600.0, 1) BY channel_group
+            | SORT watch_hours DESC
+            | LIMIT 10
+          breakdown_field: channel_group
+          metric_field: watch_hours
+
+      # ── Recent sessions ───────────────────────────────────────────────────
+      - title: Recent Sessions
+        size: {w: 48, h: 20}
+        esql:
+          type: datatable
+          query: |
+            FROM iptv.user_history
+            | WHERE @timestamp >= ?_tstart AND @timestamp <= ?_tend
+            | EVAL duration_min = ROUND(duration_seconds / 60.0, 1)
+            | EVAL data_mb = ROUND(bytes_transferred / 1048576.0, 1)
+            | KEEP @timestamp, user_name, channel_name, channel_group, duration_min, data_mb, proxy_mode
+            | SORT @timestamp DESC
+            | LIMIT 100
+          columns:
+            - field: "@timestamp"
+              label: Time
+            - field: user_name
+              label: User
+            - field: channel_name
+              label: Channel
+            - field: channel_group
+              label: Group
+            - field: duration_min
+              label: Duration (min)
+            - field: data_mb
+              label: Data (MB)
+            - field: proxy_mode
+              label: Mode
+
+    controls:
+      - type: options
+        label: User
+        data_view: iptv.user_history
+        field: user_name

--- a/dashboards/scripts/sync-skills.sh
+++ b/dashboards/scripts/sync-skills.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Sync skill markdown files from upstream repos into dashboards/skills/.
+#
+# Sources:
+#   alvarolobato/grafana-import-cli — curated Kibana/ES|QL reference docs
+#   (strawgate/kb-yaml-to-lens and elastic/agent-tools are private; grafana-import-cli
+#    already contains the combined and curated versions of those docs.)
+#
+# Idempotent: safe to re-run. IPTV-specific files (iptv-data-model.md) are never
+# overwritten by this script — edit them directly in dashboards/skills/.
+#
+# Requirements: gh (GitHub CLI authenticated), python3
+# Run from the repo root or from dashboards/scripts/:
+#   bash dashboards/scripts/sync-skills.sh
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SKILLS_DIR="$REPO_ROOT/dashboards/skills"
+mkdir -p "$SKILLS_DIR"
+
+GRAFANA_IMPORT_OWNER="alvarolobato"
+GRAFANA_IMPORT_REPO="grafana-import-cli"
+
+fetch_file() {
+  local owner="$1" repo="$2" path="$3" dest="$4"
+  local json content
+  if json=$(gh api "repos/${owner}/${repo}/contents/${path}" 2>/dev/null); then
+    content=$(python3 -c "
+import json, sys, base64
+d = json.load(sys.stdin)
+raw = (d.get('content') or '').replace('\n', '')
+sys.stdout.buffer.write(base64.b64decode(raw))
+" <<< "$json")
+    echo "$content" > "$dest"
+    echo "  fetched ${path} -> $(basename "$dest")"
+  else
+    echo "  skipping ${owner}/${repo}/${path} (no access or not found)"
+  fi
+}
+
+echo "==> Syncing skills from ${GRAFANA_IMPORT_OWNER}/${GRAFANA_IMPORT_REPO} ..."
+
+SKILLS_SOURCE="skills"
+
+fetch_file "$GRAFANA_IMPORT_OWNER" "$GRAFANA_IMPORT_REPO" \
+  "${SKILLS_SOURCE}/kibana-dashboard-yaml.md"    "$SKILLS_DIR/kibana-dashboard-yaml.md"
+
+fetch_file "$GRAFANA_IMPORT_OWNER" "$GRAFANA_IMPORT_REPO" \
+  "${SKILLS_SOURCE}/esql-language-reference.md"  "$SKILLS_DIR/esql-language-reference.md"
+
+fetch_file "$GRAFANA_IMPORT_OWNER" "$GRAFANA_IMPORT_REPO" \
+  "${SKILLS_SOURCE}/esql-query-patterns.md"      "$SKILLS_DIR/esql-query-patterns.md"
+
+fetch_file "$GRAFANA_IMPORT_OWNER" "$GRAFANA_IMPORT_REPO" \
+  "${SKILLS_SOURCE}/kibana-dashboard-style-guide.md" "$SKILLS_DIR/kibana-dashboard-style-guide.md"
+
+fetch_file "$GRAFANA_IMPORT_OWNER" "$GRAFANA_IMPORT_REPO" \
+  "${SKILLS_SOURCE}/kb-dashboard-cli-usage.md"   "$SKILLS_DIR/kb-dashboard-cli-usage.md"
+
+echo ""
+echo "NOTE: dashboards/skills/iptv-data-model.md is IPTV-specific — not synced."
+echo "Sync complete. Review changes with: git diff dashboards/skills/"

--- a/dashboards/skills/esql-language-reference.md
+++ b/dashboards/skills/esql-language-reference.md
@@ -1,0 +1,849 @@
+# ES|QL Language Reference for Dashboard Creation
+
+This guide provides essential ES|QL (Elasticsearch Query Language) syntax for LLMs creating Kibana dashboards. ES|QL is a piped query language distinct from SQL.
+
+## ES|QL vs SQL: Key Differences
+
+ES|QL is **not** SQL. Common mistakes:
+
+| SQL Syntax (Wrong) | ES|QL Syntax (Correct) |
+| ------------------ | --------------------- |
+| `SELECT * FROM logs` | `FROM logs-*` |
+| `SELECT COUNT(*) FROM logs WHERE status = 200` | `FROM logs-* \| WHERE status == 200 \| STATS COUNT(*)` |
+| `SELECT * FROM logs ORDER BY @timestamp DESC LIMIT 10` | `FROM logs-* \| SORT @timestamp DESC \| LIMIT 10` |
+| `SELECT host, COUNT(*) FROM logs GROUP BY host` | `FROM logs-* \| STATS COUNT(*) BY host` |
+| `SELECT AVG(response_time) AS avg_time FROM logs` | `FROM logs-* \| STATS avg_time = AVG(response_time)` |
+| `SELECT * FROM logs WHERE message LIKE '%error%'` | `FROM logs-* \| WHERE message LIKE "*error*"` |
+
+Key differences:
+
+- **Piped syntax**: Commands flow left-to-right with `|` (pipe) operators
+- **Equality**: Use `==` not `=` for comparison
+- **No SELECT**: Use `KEEP` to select columns, or just aggregate directly
+- **No GROUP BY clause**: Use `BY` within `STATS`
+- **Wildcards**: Use `*` in patterns, not `%`
+- **Index patterns**: FROM uses Elasticsearch index patterns (e.g., `logs-*`)
+
+### Syntax Rules
+
+**Case sensitivity:**
+
+- Keywords and function names are **case-insensitive**: `FROM`, `from`, `WHERE`, `where` all work
+- Field names are **case-sensitive**: `host.name` ≠ `Host.Name`
+- String comparisons are **case-sensitive**: `"Germany"` ≠ `"germany"`
+
+**String literals use double quotes**, not single quotes:
+
+```esql
+# Correct
+WHERE country == "Germany"
+
+# Wrong - single quotes not supported
+WHERE country == 'Germany'
+```
+
+**Always name computed columns** to avoid awkward backtick references later:
+
+```esql
+# Bad - creates column named "height * 3.281"
+| EVAL height * 3.281
+| STATS MEDIAN(`height * 3.281`)  # Must quote expression
+
+# Good - explicit name
+| EVAL height_feet = height * 3.281
+| STATS MEDIAN(height_feet)
+```
+
+---
+
+## Source Commands
+
+Every ES|QL query starts with a source command:
+
+### FROM
+
+Retrieves data from Elasticsearch indices, data streams, or aliases.
+
+```esql
+FROM logs-*
+FROM logs-*, metrics-*
+FROM logs-* METADATA _id, _index
+```
+
+### ROW
+
+Creates inline data for testing:
+
+```esql
+ROW x = 1, y = "test", z = null
+```
+
+### SHOW
+
+Returns deployment metadata:
+
+```esql
+SHOW INFO
+```
+
+### TS (Time Series)
+
+Optimized source command for time series data streams. Available in Elasticsearch 9.2+ (tech preview).
+
+```esql
+TS my_metrics
+| WHERE @timestamp >= NOW() - 1 day
+| STATS SUM(RATE(requests)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), host
+```
+
+---
+
+## Processing Commands
+
+Processing commands transform data. Chain them with `|`:
+
+### WHERE
+
+Filters rows by condition:
+
+```esql
+FROM logs-*
+| WHERE status == 200
+| WHERE response_time > 1000
+| WHERE host.name LIKE "prod-*"
+| WHERE event.category IN ("authentication", "network")
+```
+
+### STATS
+
+Aggregates data with optional grouping:
+
+```esql
+# Simple aggregation
+FROM logs-*
+| STATS total = COUNT(*)
+
+# Grouped aggregation
+FROM logs-*
+| STATS count = COUNT(*) BY host.name
+
+# Multiple aggregations
+FROM logs-*
+| STATS
+    total = COUNT(*),
+    avg_time = AVG(response_time),
+    max_time = MAX(response_time)
+  BY service.name
+
+# Conditional aggregation (inline WHERE - powerful feature)
+FROM logs-*
+| STATS
+    total = COUNT(*),
+    errors = COUNT(*) WHERE status >= 500,
+    slow_requests = COUNT(*) WHERE response_time > 1000
+  BY service.name
+
+# Time bucketing (dynamic - recommended)
+FROM logs-*
+| STATS event_count = COUNT(*) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)
+| SORT time_bucket ASC
+```
+
+### EVAL
+
+Creates or modifies columns:
+
+```esql
+FROM logs-*
+| EVAL response_time_ms = response_time * 1000
+| EVAL status_category = CASE(
+    status >= 500, "error",
+    status >= 400, "client_error",
+    status >= 300, "redirect",
+    "success"
+  )
+| EVAL is_slow = response_time > 1000
+```
+
+### KEEP
+
+Selects and orders columns:
+
+```esql
+FROM logs-*
+| KEEP @timestamp, host.name, message
+| KEEP @timestamp, host.*  # Wildcards supported
+```
+
+### DROP
+
+Removes columns:
+
+```esql
+FROM logs-*
+| DROP password, secret_key
+```
+
+### RENAME
+
+Renames columns:
+
+```esql
+FROM logs-*
+| RENAME old_name AS new_name
+| RENAME host.name AS hostname, service.name AS service
+```
+
+### SORT
+
+Orders results:
+
+```esql
+FROM logs-*
+| SORT @timestamp DESC
+| SORT status ASC, response_time DESC
+| SORT host.name ASC NULLS LAST
+```
+
+### LIMIT
+
+Restricts row count (default is 1000):
+
+```esql
+FROM logs-*
+| LIMIT 100
+```
+
+### DISSECT
+
+Extracts fields from strings using delimiter patterns:
+
+```esql
+FROM logs-*
+| DISSECT message "%{method} %{path} HTTP/%{version}"
+```
+
+### GROK
+
+Extracts fields using regex patterns:
+
+```esql
+FROM logs-*
+| GROK message "%{IP:client_ip} - %{DATA:user}"
+```
+
+### MV_EXPAND
+
+Expands multi-valued fields into separate rows:
+
+```esql
+FROM logs-*
+| MV_EXPAND tags
+```
+
+### ENRICH
+
+Adds data from enrichment policies:
+
+```esql
+FROM logs-*
+| ENRICH ip_location_policy ON client.ip WITH city, country
+```
+
+### LOOKUP JOIN
+
+Joins with a lookup index (requires `index.mode: lookup` on the lookup index):
+
+```esql
+FROM logs-*
+| LOOKUP JOIN user_lookup ON user.id
+```
+
+**Limitations:** Single shard only (max ~2B docs), no wildcards in index name, can reorder rows (always SORT after join).
+
+### FORK
+
+Splits processing into multiple branches and combines results. Useful for combining metrics from different conditions or fields:
+
+```esql
+TS metrics-*
+| FORK (
+    WHERE container.cpu.usage.kernelmode IS NOT NULL
+    | STATS cpu_rate = AVG(RATE(container.cpu.usage.kernelmode))
+      BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), container.id
+    | EVAL cpu_mode = "kernelmode"
+  )
+  (
+    WHERE container.cpu.usage.usermode IS NOT NULL
+    | STATS cpu_rate = AVG(RATE(container.cpu.usage.usermode))
+      BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), container.id
+    | EVAL cpu_mode = "usermode"
+  )
+| STATS combined_rate = AVG(cpu_rate) BY time_bucket, cpu_mode
+```
+
+**Key points:**
+
+- Each branch processes independently
+- Branches must produce compatible schemas (same columns)
+- Use `STATS` within branches when using `RATE()` (RATE can only be used in STATS)
+- Combine results after FORK with additional processing commands
+
+---
+
+## Aggregation Functions
+
+Use within STATS:
+
+| Function | Description | Example |
+| -------- | ----------- | ------- |
+| `COUNT(*)` | Count all rows | `STATS total = COUNT(*)` |
+| `COUNT(field)` | Count non-null values | `STATS errors = COUNT(error.code)` |
+| `COUNT_DISTINCT(field)` | Unique value count | `STATS unique_users = COUNT_DISTINCT(user.id)` |
+| `SUM(field)` | Sum numeric values | `STATS total_bytes = SUM(bytes)` |
+| `AVG(field)` | Average value | `STATS avg_time = AVG(response_time)` |
+| `MIN(field)` | Minimum value | `STATS min_time = MIN(response_time)` |
+| `MAX(field)` | Maximum value | `STATS max_time = MAX(response_time)` |
+| `MEDIAN(field)` | Median value | `STATS median_time = MEDIAN(response_time)` |
+| `PERCENTILE(field, n)` | Nth percentile | `STATS p95 = PERCENTILE(response_time, 95.0)` |
+| `STD_DEV(field)` | Standard deviation | `STATS stddev = STD_DEV(response_time)` |
+| `VARIANCE(field)` | Variance | `STATS var = VARIANCE(response_time)` |
+| `VALUES(field)` | All unique values | `STATS hosts = VALUES(host.name)` |
+| `TOP(field, n, order)` | Top N values | `STATS top_hosts = TOP(host.name, 5, "desc")` |
+
+---
+
+## Time Series Functions
+
+For use with the TS source command (Elasticsearch 9.2+):
+
+| Function | Description | Example |
+| -------- | ----------- | ------- |
+| `RATE(field)` | Per-second rate of counter increase | `STATS SUM(RATE(requests))` |
+| `IRATE(field)` | Instant rate (last two points) | `STATS SUM(IRATE(requests))` |
+
+**Important:** `RATE()` and `IRATE()` can **only** be used within `STATS` commands (or other aggregate functions). They cannot be used directly in `EVAL` or `WHERE` clauses:
+
+```esql
+# CORRECT - RATE() inside STATS
+TS metrics-*
+| STATS request_rate = SUM(RATE(requests))
+
+# CORRECT - RATE() inside STATS within FORK branch
+TS metrics-*
+| FORK (
+    WHERE field1 IS NOT NULL
+    | STATS rate1 = AVG(RATE(field1))
+  )
+  (
+    WHERE field2 IS NOT NULL
+    | STATS rate2 = AVG(RATE(field2))
+  )
+
+# WRONG - RATE() cannot be used in EVAL
+TS metrics-*
+| EVAL rate = RATE(requests)  # Error: RATE can only be used in STATS
+```
+
+| `DELTA(field)` | Absolute change of gauge | `STATS SUM(DELTA(temperature))` |
+| `IDELTA(field)` | Instant delta (last two points) | `STATS SUM(IDELTA(gauge))` |
+| `INCREASE(field)` | Absolute increase of counter | `STATS SUM(INCREASE(total_bytes))` |
+| `AVG_OVER_TIME(field)` | Average over time window | `STATS MAX(AVG_OVER_TIME(cpu))` |
+| `MAX_OVER_TIME(field)` | Maximum over time window | `STATS MAX(MAX_OVER_TIME(memory))` |
+| `MIN_OVER_TIME(field)` | Minimum over time window | `STATS MIN(MIN_OVER_TIME(latency))` |
+| `SUM_OVER_TIME(field)` | Sum over time window | `STATS SUM(SUM_OVER_TIME(bytes))` |
+| `COUNT_OVER_TIME(field)` | Count over time window | `STATS SUM(COUNT_OVER_TIME(events))` |
+| `FIRST_OVER_TIME(field)` | Earliest value by timestamp | `STATS MAX(FIRST_OVER_TIME(value))` |
+| `LAST_OVER_TIME(field)` | Latest value by timestamp | `STATS MAX(LAST_OVER_TIME(value))` |
+
+**Important:** All `*_OVER_TIME()` functions **must** be wrapped in another aggregate function like `AVG()`, `MAX()`, `MIN()`, or `SUM()`. They cannot be used directly:
+
+```esql
+# CORRECT - AVG_OVER_TIME wrapped in MAX()
+TS metrics-*
+| STATS avg_cpu = MAX(AVG_OVER_TIME(system.cpu.utilization))
+
+# CORRECT - LAST_OVER_TIME wrapped in MAX()
+TS metrics-*
+| STATS connections = MAX(LAST_OVER_TIME(postgresql.backends))
+
+# WRONG - *_OVER_TIME() must be wrapped in aggregate
+TS metrics-*
+| STATS cpu = AVG_OVER_TIME(system.cpu.utilization)  # Error: must be wrapped
+```
+
+### Choosing the Right Gauge Aggregation
+
+For **gauge metrics** (point-in-time values like connections, memory, counts), choose based on what question you're answering:
+
+| Use Case | Function | When to Use |
+| -------- | -------- | ----------- |
+| Current state | `LAST_OVER_TIME()` | Connection counts, thread counts, buffer sizes, queue depths - "what is the value now?" |
+| Typical value | `AVG_OVER_TIME()` | CPU utilization, memory percentage, load averages - "what is the typical value?" |
+| Peak detection | `MAX_OVER_TIME()` | Finding spikes in latency, memory high-water marks |
+| Minimum threshold | `MIN_OVER_TIME()` | Detecting drops in available resources |
+
+**Recommended patterns:**
+
+```esql
+# Current active connections (use LAST_OVER_TIME for current state)
+TS metrics-*
+| STATS connections = MAX(LAST_OVER_TIME(postgresql.backends))
+
+# Average CPU over time (use AVG_OVER_TIME for typical value)
+TS metrics-*
+| STATS avg_cpu = MAX(AVG_OVER_TIME(system.cpu.utilization))
+
+# Peak memory usage (use MAX_OVER_TIME for high-water mark)
+TS metrics-*
+| STATS peak_memory = MAX(MAX_OVER_TIME(process.memory.usage))
+```
+
+**Note:** When aggregating across multiple time series (e.g., multiple hosts), wrap with `MAX()`, `SUM()`, or `AVG()` as appropriate for your use case.
+
+### Dynamic Time Bucketing (Required)
+
+Time bucketing function (for use with TS source command):
+
+**Always use the 4-parameter `BUCKET()` syntax** for time series charts so they scale with the user's selected time range. This works with both `FROM` and `TS` queries:
+
+```esql
+# With FROM queries
+FROM logs-*
+| STATS event_count = COUNT(*) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)
+| SORT time_bucket ASC
+
+# With TS queries
+TS metrics-*
+| STATS rate = SUM(RATE(requests)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)
+| SORT time_bucket ASC
+```
+
+| Parameter | Description |
+| --------- | ----------- |
+| `@timestamp` | The timestamp field to bucket |
+| `20` | Target number of buckets (20-50 recommended) |
+| `?_tstart` | Kibana time range start parameter (auto-populated) |
+| `?_tend` | Kibana time range end parameter (auto-populated) |
+
+This ensures visualizations remain readable whether the user views 5 minutes or 1 year of data. The `?_tstart` and `?_tend` parameters are automatically populated by Kibana based on the dashboard time picker.
+
+**Why dynamic bucketing is essential:**
+
+- Fixed intervals like `BUCKET(@timestamp, 1 minute)` create 10,080 data points for 1 week
+- Fixed intervals like `BUCKET(@timestamp, 5 minutes)` create 2,016 data points for 1 week
+- `BUCKET(@timestamp, 20, ?_tstart, ?_tend)` creates exactly ~20 data points regardless of time range
+
+**Note:** `TBUCKET(interval)` is an alias for `BUCKET(@timestamp, interval)` but should be avoided because it uses fixed intervals that don't scale with the dashboard time range.
+
+---
+
+## Common Functions
+
+### String Functions
+
+| Function | Description | Example |
+| -------- | ----------- | ------- |
+| `LENGTH(s)` | String length | `EVAL len = LENGTH(message)` |
+| `SUBSTRING(s, start, len)` | Extract substring | `EVAL prefix = SUBSTRING(host, 0, 4)` |
+| `CONCAT(s1, s2, ...)` | Concatenate strings | `EVAL full = CONCAT(first, " ", last)` |
+| `TO_LOWER(s)` | Lowercase | `EVAL lower = TO_LOWER(name)` |
+| `TO_UPPER(s)` | Uppercase | `EVAL upper = TO_UPPER(name)` |
+| `TRIM(s)` | Remove whitespace | `EVAL clean = TRIM(input)` |
+| `REPLACE(s, old, new)` | Replace substring | `EVAL fixed = REPLACE(msg, "err", "error")` |
+| `SPLIT(s, delim)` | Split into array | `EVAL parts = SPLIT(path, "/")` |
+| `MV_FIRST(array)` | First element of array | `EVAL first = MV_FIRST(parts)` |
+| `MV_LAST(array)` | Last element of array | `EVAL last = MV_LAST(parts)` |
+
+**Array access:** ES|QL doesn't support bracket indexing like `array[0]`. Use `MV_FIRST()` and `MV_LAST()` to access array elements:
+
+```esql
+# Split image name and extract name/version
+FROM metrics-*
+| EVAL image_parts = SPLIT(container.image.name, ":")
+| EVAL image_name = MV_FIRST(image_parts)
+| EVAL image_version = CASE(MV_FIRST(image_parts) == MV_LAST(image_parts), "latest", MV_LAST(image_parts))
+```
+
+### Date/Time Functions
+
+| Function | Description | Example |
+| -------- | ----------- | ------- |
+| `NOW()` | Current timestamp | `WHERE @timestamp > NOW() - 1 hour` |
+| `DATE_EXTRACT(unit, date)` | Extract date part | `EVAL hour = DATE_EXTRACT("hour", @timestamp)` |
+| `DATE_TRUNC(unit, date)` | Truncate to unit | `EVAL day = DATE_TRUNC("day", @timestamp)` |
+| `DATE_DIFF(unit, d1, d2)` | Difference between dates | `EVAL age_days = DATE_DIFF("day", created, NOW())` |
+| `DATE_FORMAT(date, fmt)` | Format date as string | `EVAL formatted = DATE_FORMAT(@timestamp, "yyyy-MM-dd")` |
+| `DATE_PARSE(fmt, s)` | Parse string to date | `EVAL parsed = DATE_PARSE("yyyy-MM-dd", date_str)` |
+| `BUCKET(field, count, start, end)` | Dynamic bucketing for date/numeric fields | `STATS count = COUNT(*) BY BUCKET(@timestamp, 20, ?_tstart, ?_tend)` |
+
+### Numeric Functions
+
+| Function | Description | Example |
+| -------- | ----------- | ------- |
+| `ABS(n)` | Absolute value | `EVAL abs_val = ABS(change)` |
+| `CEIL(n)` | Round up | `EVAL ceiling = CEIL(value)` |
+| `FLOOR(n)` | Round down | `EVAL floored = FLOOR(value)` |
+| `ROUND(n, decimals)` | Round to decimals | `EVAL rounded = ROUND(avg, 2)` |
+| `POW(base, exp)` | Power | `EVAL squared = POW(x, 2)` |
+| `SQRT(n)` | Square root | `EVAL root = SQRT(variance)` |
+| `LOG10(n)` | Base-10 logarithm | `EVAL log = LOG10(value)` |
+
+### Conditional Functions
+
+| Function | Description | Example |
+| -------- | ----------- | ------- |
+| `CASE(cond1, val1, ...)` | Conditional logic | `EVAL status = CASE(code >= 500, "error", code >= 400, "warn", "ok")` |
+| `COALESCE(v1, v2, ...)` | First non-null | `EVAL name = COALESCE(display_name, username, "unknown")` |
+| `GREATEST(v1, v2, ...)` | Maximum value | `EVAL max = GREATEST(a, b, c)` |
+| `LEAST(v1, v2, ...)` | Minimum value | `EVAL min = LEAST(a, b, c)` |
+
+### Type Conversion Functions
+
+| Function | Description | Example |
+| -------- | ----------- | ------- |
+| `TO_STRING(v)` | Convert to string | `EVAL str = TO_STRING(status_code)` |
+| `TO_INTEGER(v)` | Convert to integer | `EVAL num = TO_INTEGER(count_str)` |
+| `TO_DOUBLE(v)` | Convert to double | `EVAL dbl = TO_DOUBLE(value)` |
+| `TO_BOOLEAN(v)` | Convert to boolean | `EVAL flag = TO_BOOLEAN(enabled)` |
+| `TO_DATETIME(v)` | Convert to datetime | `EVAL ts = TO_DATETIME(timestamp_str)` |
+| `TO_IP(v)` | Convert to IP | `EVAL ip = TO_IP(ip_string)` |
+
+---
+
+## Operators
+
+### Comparison Operators
+
+| Operator | Description | Example |
+| -------- | ----------- | ------- |
+| `==` | Equal | `WHERE status == 200` |
+| `!=` | Not equal | `WHERE status != 500` |
+| `<` | Less than | `WHERE response_time < 100` |
+| `<=` | Less than or equal | `WHERE count <= 10` |
+| `>` | Greater than | `WHERE bytes > 1000` |
+| `>=` | Greater than or equal | `WHERE score >= 0.5` |
+| `LIKE` | Pattern match (wildcards) | `WHERE host LIKE "prod-*"` |
+| `RLIKE` | Regex match | `WHERE message RLIKE "error.*timeout"` |
+| `IN` | In list | `WHERE status IN (200, 201, 204)` |
+| `IS NULL` | Null check | `WHERE error IS NULL` |
+| `IS NOT NULL` | Not null check | `WHERE response IS NOT NULL` |
+
+### Logical Operators
+
+| Operator | Description | Example |
+| -------- | ----------- | ------- |
+| `AND` | Logical AND | `WHERE status == 200 AND response_time < 100` |
+| `OR` | Logical OR | `WHERE status == 500 OR status == 503` |
+| `NOT` | Logical NOT | `WHERE NOT host LIKE "test-*"` |
+
+### Arithmetic Operators
+
+| Operator | Description | Example |
+| -------- | ----------- | ------- |
+| `+` | Addition | `EVAL total = sent + received` |
+| `-` | Subtraction | `EVAL diff = end - start` |
+| `*` | Multiplication | `EVAL bytes = kb * 1024` |
+| `/` | Division | `EVAL rate = count / duration` |
+| `%` | Modulo | `EVAL remainder = value % 10` |
+
+---
+
+## Dashboard Query Patterns
+
+### Metric Panel Queries
+
+Single-value metrics:
+
+```esql
+# Total count
+FROM logs-*
+| STATS total_events = COUNT(*)
+
+# Average with breakdown
+FROM logs-*
+| STATS avg_response = AVG(response_time), p95 = PERCENTILE(response_time, 95.0) BY service.name
+```
+
+### Time Series Charts
+
+```esql
+# Events over time (adaptive bucketing - recommended)
+FROM logs-*
+| STATS event_count = COUNT(*) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)
+| SORT time_bucket ASC
+
+# Events by category over time (adaptive bucketing)
+FROM logs-*
+| STATS event_count = COUNT(*) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), event.category
+| SORT time_bucket ASC
+
+# Bytes transferred over time with breakdown
+FROM logs-*
+| STATS total_bytes = SUM(bytes) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), host.name
+| SORT time_bucket ASC
+```
+
+### Pie/Donut Charts
+
+```esql
+# Top 10 event categories
+FROM logs-*
+| STATS count = COUNT(*) BY event.category
+| SORT count DESC
+| LIMIT 10
+
+# Browser distribution
+FROM logs-*
+| STATS users = COUNT_DISTINCT(user.id) BY user_agent.name
+| SORT users DESC
+| LIMIT 5
+```
+
+### Bar Charts
+
+```esql
+# Top hosts by request count
+FROM logs-*
+| STATS requests = COUNT(*) BY host.name
+| SORT requests DESC
+| LIMIT 10
+
+# Error codes distribution
+FROM logs-*
+| WHERE status >= 400
+| STATS errors = COUNT(*) BY status
+| SORT errors DESC
+```
+
+### Data Tables
+
+```esql
+# Recent errors with context
+FROM logs-*
+| WHERE log.level == "error"
+| KEEP @timestamp, host.name, message, error.type
+| SORT @timestamp DESC
+| LIMIT 100
+
+# Top talkers summary
+FROM logs-*
+| STATS
+    total_requests = COUNT(*),
+    total_bytes = SUM(bytes),
+    avg_response = AVG(response_time)
+  BY source.ip
+| SORT total_requests DESC
+| LIMIT 20
+```
+
+---
+
+## Common Mistakes to Avoid
+
+!!! tip "Automatic Detection"
+    Many of these mistakes are automatically detected by the dashboard linter.
+    Run `kb-dashboard-lint` on your YAML files to catch issues early.
+
+1. **Using SQL syntax**: ES|QL is not SQL. No SELECT, FROM comes first, use `|` pipes.
+   *Lint rule: `esql-sql-syntax`*
+
+2. **Wrong equality operator**: Use `==` for comparison, not `=`.
+   *Lint rule: `esql-sql-syntax`*
+
+3. **Missing pipes**: Commands must be separated by `|`.
+
+4. **GROUP BY in wrong place**: Use `BY` within `STATS`, not as separate clause.
+
+5. **Wrong wildcard character**: Use `*` in LIKE patterns, not `%`.
+   *Lint rule: `esql-sql-syntax`*
+
+6. **Forgetting SORT for time series**: Add `SORT time_bucket ASC` for charts.
+
+7. **Using BUCKET as standalone command**: `BUCKET()` must be used within STATS...BY or EVAL, not as a separate command.
+
+8. **Case sensitivity**: Field names are case-sensitive.
+
+9. **Missing time filter**: Add `WHERE @timestamp >= NOW() - 1 day` for performance.
+   *Lint rule: `esql-where-clause`*
+
+10. **Assuming default order**: Always explicit SORT for predictable results.
+
+11. **Using window functions**: ES|QL has no `ROW_NUMBER() OVER (PARTITION BY ...)`. Use `VALUES()` + `MV_SORT()` + `MV_FIRST()`/`MV_LAST()` for latest-per-group patterns.
+
+12. **Hardcoded time buckets**: Always use dynamic sizing ``BUCKET(`@timestamp`, 20, ?_tstart, ?_tend)`` for both FROM and TS queries so visualizations scale with the time range. Avoid fixed intervals like ``BUCKET(`@timestamp`, 1 minute)`` or ``TBUCKET(5 minutes)`` as they create too many data points for long time ranges.
+    *Lint rule: `esql-dynamic-time-bucket`*
+
+13. **Multivalue fields return NULL**: Most functions silently return NULL on multivalue fields. Use `MV_EXPAND` first:
+
+    ```esql
+    # Wrong - returns no hits on array fields
+    WHERE tags LIKE "*error*"
+
+    # Correct - expand first
+    | MV_EXPAND tags
+    | WHERE tags LIKE "*error*"
+    ```
+
+14. **Type mismatch across indices**: Same field with different types causes errors. Fix with explicit conversion:
+
+    ```esql
+    # Error: client_ip mapped as [ip] in one index, [keyword] in another
+    # Fix: Convert to consistent type
+    FROM events_*
+    | EVAL client_ip = TO_IP(client_ip)
+    ```
+
+15. **Late filtering wastes resources**: Filter on indexed fields immediately after FROM for Lucene pushdown:
+
+    ```esql
+    # Bad - processes all documents first
+    FROM logs-*
+    | DISSECT message "%{action}"
+    | WHERE @timestamp > NOW() - 1h
+
+    # Good - filter first for Lucene pushdown
+    FROM logs-*
+    | WHERE @timestamp > NOW() - 1h
+    | DISSECT message "%{action}"
+    ```
+
+16. **Type conversions fail silently**: Failed conversions return NULL with warnings, not errors. Check results:
+
+    ```esql
+    ROW str = "not_a_number" | EVAL num = TO_DOUBLE(str)
+    # Returns null, emits warning in response headers
+    ```
+
+---
+
+## OpenTelemetry Data Patterns
+
+When querying OpenTelemetry metrics data, follow these patterns:
+
+### Field Path Conventions
+
+OTel data uses specific field path patterns:
+
+```esql
+# Metric values - use metric name directly
+TS metrics-*
+| WHERE apache.requests IS NOT NULL
+
+# Metric attributes - always prefix with "attributes."
+TS metrics-*
+| WHERE attributes.state == "running"
+
+# Resource attributes - use full path
+TS metrics-*
+| WHERE resource.attributes.service.name == "my-service"
+
+# Filter by data stream
+TS metrics-*
+| WHERE data_stream.dataset == "apachereceiver.otel"
+```
+
+### Counter vs Gauge Metrics
+
+**Counter metrics** (cumulative, always increasing) must use `RATE()`:
+
+```esql
+# CORRECT - Use RATE() for counters
+TS metrics-*
+| STATS request_rate = SUM(RATE(apache.requests))
+
+# WRONG - MAX() on counter gives cumulative total
+FROM metrics-*
+| STATS requests = MAX(apache.requests)
+```
+
+**Gauge metrics** (point-in-time values) use `*_OVER_TIME()` functions. Choose based on your use case:
+
+| Gauge Type | Function | Examples |
+| ---------- | -------- | -------- |
+| Current state | `LAST_OVER_TIME()` | Connection counts, buffer sizes, queue depths |
+| Typical value | `AVG_OVER_TIME()` | CPU utilization, memory percentage |
+
+```esql
+# Current value - use LAST_OVER_TIME for "what is it now?"
+TS metrics-*
+| STATS connections = MAX(LAST_OVER_TIME(mysql.connections))
+
+# Average over time - use AVG_OVER_TIME for "what is the typical value?"
+TS metrics-*
+| STATS avg_cpu = MAX(AVG_OVER_TIME(system.cpu.utilization))
+```
+
+### Escaping Special Field Names
+
+Field names with numeric suffixes require backticks.
+*Lint rule: `esql-field-escaping`*
+
+```esql
+# WRONG - Parser error
+WHERE apache.load.1 IS NOT NULL
+
+# CORRECT - Backtick escape
+WHERE `apache.load.1` IS NOT NULL
+| STATS load = AVG(AVG_OVER_TIME(`apache.load.1`))
+```
+
+### Dimensional Queries
+
+Filter or group by metric dimensions using the `attributes` prefix:
+
+```esql
+# Filter by dimension value
+TS metrics-*
+| WHERE attributes.operation == "insert"
+| STATS ops = SUM(RATE(mysql.operations))
+
+# Group by dimension
+TS metrics-*
+| STATS ops = SUM(RATE(mysql.operations)) BY operation = attributes.operation
+```
+
+For comprehensive OTel dashboard guidance, see [Creating Dashboards from OTel Receivers](otel-dashboard-guide.md).
+
+---
+
+## Key Limitations
+
+| Limitation | Detail |
+| ---------- | ------ |
+| Row limit | Default 1,000 rows, max 10,000 (output only, not docs processed) |
+| Timeout | 30-second default regardless of Kibana settings |
+| Timezone | ES\|QL only supports UTC |
+| Nested fields | Not returned at all |
+| Subqueries | Not supported—use ENRICH or LOOKUP JOIN |
+| BUCKET gaps | Does not create empty buckets for missing time intervals |
+| date_nanos | Partial support—cast to datetime for BUCKET, DATE_FORMAT, DATE_PARSE |
+
+---
+
+## Quick Reference: Pipeline Order
+
+Optimal command ordering for performance:
+
+```esql
+FROM logs-*                              -- 1. Source command
+| WHERE @timestamp > NOW() - 1h          -- 2. Filter indexed fields (Lucene pushdown)
+| KEEP @timestamp, status, message       -- 3. Drop unused columns early
+| EVAL status_group = status / 100       -- 4. Compute new columns
+| DISSECT message "%{method} %{path}"    -- 5. Parse unstructured data
+| ENRICH geo_policy ON client.ip         -- 6. Add reference data
+| LOOKUP JOIN users ON user.id           -- 7. Join with lookup data
+| WHERE status_group == 5                -- 8. Filter on computed values
+| STATS count = COUNT(*) BY path         -- 9. Aggregate
+| SORT count DESC                        -- 10. Sort (after aggregation)
+| LIMIT 100                              -- 11. Cap output rows
+```
+
+---
+
+## Additional Resources
+
+- [ESQL Panel Configuration](../panels/esql.md) - Dashboard panel setup
+- [ES|QL Query Reuse with YAML Anchors](../advanced/esql-views.md) - Query patterns
+- [Queries Configuration](../queries/config.md#esql-query) - Query format options
+- [Elastic ES|QL Reference](https://www.elastic.co/docs/reference/query-languages/esql) - Official documentation

--- a/dashboards/skills/esql-query-patterns.md
+++ b/dashboards/skills/esql-query-patterns.md
@@ -1,0 +1,709 @@
+# ES|QL Query Patterns
+
+Common patterns for generating ES|QL queries from natural language requests.
+
+## Pattern Recognition Guide
+
+When translating natural language to ES|QL, identify these key elements:
+
+| User Says                               | ES\|QL Element                            |
+| --------------------------------------- | ----------------------------------------- |
+| "show", "list", "get", "find"           | `FROM` + `KEEP` (select fields)           |
+| "from", "in" (index)                    | `FROM index-pattern`                      |
+| "where", "with", "that have", "filter"  | `WHERE condition`                         |
+| "last X hours/days", "since", "between" | `WHERE @timestamp > NOW() - X time`       |
+| "count", "how many"                     | `STATS count = COUNT(*)`                  |
+| "average", "mean"                       | `STATS avg = AVG(field)`                  |
+| "total", "sum"                          | `STATS total = SUM(field)`                |
+| "maximum", "highest", "top value"       | `STATS max = MAX(field)`                  |
+| "minimum", "lowest"                     | `STATS min = MIN(field)`                  |
+| "by", "per", "grouped by", "for each"   | `... BY field`                            |
+| "top N", "first N", "limit"             | `LIMIT N`                                 |
+| "sorted by", "order by"                 | `SORT field [DESC/ASC]`                   |
+| "unique", "distinct"                    | `COUNT_DISTINCT(field)`                   |
+| "contains", "includes"                  | `WHERE field LIKE "*value*"` or `MATCH()` |
+| "starts with"                           | `WHERE STARTS_WITH(field, "prefix")`      |
+| "ends with"                             | `WHERE ENDS_WITH(field, "suffix")`        |
+
+---
+
+## Time-Based Queries
+
+### Recent Data
+
+```
+"show errors from the last hour"
+→
+FROM logs-*
+| WHERE @timestamp > NOW() - 1 hour
+| WHERE level == "error"
+| SORT @timestamp DESC
+| LIMIT 100
+```
+
+### Time Range
+
+```
+"events between January 1 and January 15, 2024"
+→
+FROM events-*
+| WHERE @timestamp >= "2024-01-01" AND @timestamp < "2024-01-16"
+```
+
+### Time Bucketing
+
+```
+"count events per hour for today"
+→
+FROM events-*
+| WHERE @timestamp > NOW() - 24 hours
+| STATS count = COUNT(*) BY bucket = DATE_TRUNC(1 hour, @timestamp)
+| SORT bucket DESC
+```
+
+### Time Comparisons
+
+```
+"requests slower than 5 seconds"
+→
+FROM api-logs
+| WHERE response_time > 5000
+| SORT response_time DESC
+| LIMIT 100
+```
+
+---
+
+## Aggregation Patterns
+
+### Simple Count
+
+```
+"how many errors are there"
+→
+FROM logs-*
+| WHERE level == "error"
+| STATS total_errors = COUNT(*)
+```
+
+### Count by Category
+
+```
+"count of events by status code"
+→
+FROM web-logs
+| STATS count = COUNT(*) BY status_code
+| SORT count DESC
+```
+
+### Multiple Aggregations
+
+```
+"show min, max, and average response time"
+→
+FROM api-logs
+| STATS
+    min_time = MIN(response_time),
+    max_time = MAX(response_time),
+    avg_time = AVG(response_time)
+```
+
+### Grouped Multiple Aggregations
+
+```
+"average and max CPU per host"
+→
+FROM metrics-*
+| STATS
+    avg_cpu = AVG(system.cpu.percent),
+    max_cpu = MAX(system.cpu.percent)
+  BY host.name
+| SORT avg_cpu DESC
+```
+
+### Top N Pattern
+
+```
+"top 10 hosts by error count"
+→
+FROM logs-*
+| WHERE level == "error"
+| STATS error_count = COUNT(*) BY host.name
+| SORT error_count DESC
+| LIMIT 10
+```
+
+### Percentiles
+
+```
+"p50, p95, p99 response times by endpoint"
+→
+FROM api-logs
+| STATS
+    p50 = PERCENTILE(response_time, 50),
+    p95 = PERCENTILE(response_time, 95),
+    p99 = PERCENTILE(response_time, 99)
+  BY endpoint
+| SORT p99 DESC
+```
+
+### Unique Counts
+
+```
+"count of unique users per day"
+→
+FROM user-events
+| STATS unique_users = COUNT_DISTINCT(user_id) BY day = DATE_TRUNC(1 day, @timestamp)
+| SORT day DESC
+```
+
+---
+
+## Filtering Patterns
+
+### Exact Match
+
+```
+"errors from production"
+→
+FROM logs-*
+| WHERE level == "error" AND environment == "production"
+```
+
+### Multiple Values (IN)
+
+```
+"events with status 400, 401, or 403"
+→
+FROM web-logs
+| WHERE status_code IN (400, 401, 403)
+```
+
+### Pattern Matching
+
+```
+"requests to /api endpoints"
+→
+FROM web-logs
+| WHERE url LIKE "/api/*"
+```
+
+### Full-Text Search (8.17+)
+
+```
+"documents containing 'connection timeout'"
+→
+FROM logs-* METADATA _score
+| WHERE MATCH(message, "connection timeout")
+| SORT _score DESC
+| LIMIT 100
+```
+
+### Null Handling
+
+```
+"records where error field exists"
+→
+FROM logs-*
+| WHERE error IS NOT NULL
+```
+
+### Negation
+
+```
+"all events except from test environment"
+→
+FROM events-*
+| WHERE environment != "test"
+```
+
+---
+
+## Transformation Patterns
+
+### Computed Fields
+
+```
+"show response time in seconds"
+→
+FROM api-logs
+| EVAL response_time_sec = response_time_ms / 1000
+| KEEP endpoint, response_time_sec
+```
+
+### String Manipulation
+
+```
+"extract domain from email addresses"
+→
+FROM users
+| EVAL domain = SUBSTRING(email, LOCATE("@", email) + 1, LENGTH(email))
+| KEEP email, domain
+```
+
+### Conditional Values
+
+```
+"categorize response times as fast/medium/slow"
+→
+FROM api-logs
+| EVAL speed_category = CASE(
+    response_time < 100, "fast",
+    response_time < 500, "medium",
+    "slow"
+  )
+| STATS count = COUNT(*) BY speed_category
+```
+
+### Rate Calculation
+
+```
+"error rate percentage by service"
+→
+FROM logs-*
+| STATS
+    total = COUNT(*),
+    errors = COUNT(CASE(level == "error", 1, null))
+  BY service.name
+| EVAL error_rate = ROUND(errors * 100.0 / total, 2)
+| SORT error_rate DESC
+```
+
+---
+
+## Log Parsing Patterns
+
+### GROK for Structured Extraction
+
+```
+"parse Apache access logs"
+→
+FROM raw-logs
+| GROK message "%{IP:client_ip} - - \\[%{HTTPDATE:timestamp}\\] \"%{WORD:method} %{URIPATHPARAM:path} HTTP/%{NUMBER:http_version}\" %{NUMBER:status:int} %{NUMBER:bytes:int}"
+| KEEP client_ip, method, path, status, bytes
+```
+
+### DISSECT for Simple Patterns
+
+```
+"extract user and action from 'User X performed Y'"
+→
+FROM audit-logs
+| DISSECT message "User %{user} performed %{action}"
+| STATS count = COUNT(*) BY user, action
+```
+
+---
+
+## Advanced Patterns
+
+### Multi-Index Query
+
+```
+"combine data from logs and metrics"
+→
+FROM logs-*, metrics-*
+| WHERE @timestamp > NOW() - 1 hour
+| KEEP @timestamp, host.name, message, cpu.percent
+```
+
+### Data Enrichment
+
+```
+"add geo info to IP addresses"
+→
+FROM web-logs
+| ENRICH geoip-policy ON client.ip WITH country_name, city_name
+| STATS requests = COUNT(*) BY country_name
+| SORT requests DESC
+```
+
+### Multivalue Handling
+
+```
+"count occurrences of each tag"
+→
+FROM documents
+| MV_EXPAND tags
+| STATS count = COUNT(*) BY tags
+| SORT count DESC
+```
+
+### Chained Aggregations
+
+```
+"average daily count per week"
+→
+FROM events
+| STATS daily_count = COUNT(*) BY day = DATE_TRUNC(1 day, @timestamp)
+| STATS avg_daily = AVG(daily_count) BY week = DATE_TRUNC(1 week, day)
+| SORT week DESC
+```
+
+---
+
+## Common Mistakes to Avoid
+
+1. **Forgetting LIMIT** - Always add `LIMIT` to prevent returning too many rows
+
+2. **Wrong time field** - Common names: `@timestamp`, `timestamp`, `time`, `date`
+
+3. **Case sensitivity** - Field names are case-sensitive: `host.Name` ≠ `host.name`
+
+4. **String vs Keyword** - Use `.keyword` suffix for exact matches on text fields:
+
+   ```esql
+   WHERE status.keyword == "active"
+   ```
+
+5. **Type mismatches** - Convert types when needed:
+
+   ```esql
+   | EVAL num = TO_INTEGER(string_field)
+   ```
+
+6. **STATS without aggregation** - STATS requires aggregate functions:
+
+   ```esql
+   // Wrong: | STATS BY host
+   // Right: | STATS count = COUNT(*) BY host
+   ```
+
+7. **Missing FROM** - Every query must start with a source command
+
+8. **Pipe placement** - Each command needs a pipe before it (except FROM)
+
+---
+
+# ES|QL Query Generation Tips
+
+Guidelines for generating accurate ES|QL queries from natural language.
+
+## Step-by-Step Generation Process
+
+### 1. Identify the Data Source
+
+**Question:** What index or data should be queried?
+
+- Look for index names, data types, or subject areas mentioned
+- Common patterns: `logs-*`, `metrics-*`, `events-*`, `apm-*`
+- If unclear, use wildcards or ask for clarification
+
+```esql
+FROM logs-*           // Generic logs
+FROM metrics-*        // Metrics data
+FROM .ds-*            // Data streams
+FROM my-index-2024.*  // Dated indices
+```
+
+### 2. Determine Time Range
+
+**Question:** What time period should be covered?
+
+| User Expression | ES\|QL                                                             |
+| --------------- | ------------------------------------------------------------------ |
+| "last hour"     | `@timestamp > NOW() - 1 hour`                                      |
+| "last 24 hours" | `@timestamp > NOW() - 24 hours`                                    |
+| "last 7 days"   | `@timestamp > NOW() - 7 days`                                      |
+| "today"         | `@timestamp > NOW() - 24 hours`                                    |
+| "yesterday"     | `@timestamp >= NOW() - 48 hours AND @timestamp < NOW() - 24 hours` |
+| "this week"     | `@timestamp > NOW() - 7 days`                                      |
+| "this month"    | `@timestamp > NOW() - 30 days`                                     |
+
+**Default:** If no time range specified, consider adding a reasonable default (e.g., last 24 hours) to avoid scanning too much data.
+
+### 3. Identify Filters
+
+**Question:** What conditions should narrow the results?
+
+Look for:
+
+- Status/level: "errors", "warnings", "successful"
+- Environment: "production", "staging", "dev"
+- Source/host: specific servers, services, applications
+- Values: specific codes, IDs, names
+
+```esql
+// Multiple filters
+| WHERE level == "error"
+| WHERE environment == "production"
+| WHERE service.name == "api-gateway"
+```
+
+Or combined:
+
+```esql
+| WHERE level == "error" AND environment == "production" AND service.name == "api-gateway"
+```
+
+### 4. Determine Output Type
+
+**Question:** Does the user want raw data or aggregated results?
+
+| User Intent                   | Approach                        |
+| ----------------------------- | ------------------------------- |
+| "show me", "list", "find"     | Raw data with KEEP, SORT, LIMIT |
+| "count", "how many"           | STATS with COUNT                |
+| "average", "total", "sum"     | STATS with aggregation function |
+| "by X", "per X", "grouped by" | STATS ... BY grouping           |
+| "top N", "most common"        | STATS + SORT DESC + LIMIT       |
+| "distribution", "breakdown"   | STATS COUNT BY category         |
+| "over time", "trend"          | STATS BY DATE_TRUNC             |
+
+### 5. Select Fields
+
+**Question:** What fields should be shown?
+
+For raw data queries, use KEEP to select relevant fields:
+
+```esql
+| KEEP @timestamp, host.name, message, level
+```
+
+For aggregations, the output fields are defined by STATS:
+
+```esql
+| STATS count = COUNT(*), avg_time = AVG(response_time) BY endpoint
+```
+
+### 6. Apply Ordering and Limits
+
+**Question:** How should results be ordered and limited?
+
+- Time-based: `SORT @timestamp DESC`
+- By count/value: `SORT count DESC`
+- Alphabetical: `SORT name ASC`
+
+**Always add LIMIT** unless the user specifically wants all results:
+
+```esql
+| LIMIT 100  // Reasonable default
+| LIMIT 1000 // Maximum before considering pagination
+```
+
+---
+
+## Field Name Conventions
+
+When generating queries, use common field naming conventions:
+
+### Elastic Common Schema (ECS)
+
+| Category    | Common Fields                                                  |
+| ----------- | -------------------------------------------------------------- |
+| Timestamp   | `@timestamp`                                                   |
+| Message     | `message`                                                      |
+| Log level   | `log.level`, `level`                                           |
+| Host        | `host.name`, `host.ip`                                         |
+| Service     | `service.name`, `service.type`                                 |
+| HTTP        | `http.request.method`, `http.response.status_code`, `url.path` |
+| User        | `user.name`, `user.id`                                         |
+| Source      | `source.ip`, `source.port`                                     |
+| Destination | `destination.ip`, `destination.port`                           |
+| Error       | `error.message`, `error.type`                                  |
+| Event       | `event.action`, `event.category`, `event.outcome`              |
+
+### Legacy/Custom Fields
+
+Some indices may use non-ECS field names:
+
+- `status_code` instead of `http.response.status_code`
+- `hostname` instead of `host.name`
+- `timestamp` instead of `@timestamp`
+
+**Recommendation:** When unsure, use `./esql.js schema <index>` to discover actual field names.
+
+---
+
+## Query Optimization Tips
+
+### 1. Filter Early
+
+Put WHERE clauses as early as possible:
+
+```esql
+// Good - filter first
+FROM logs-*
+| WHERE @timestamp > NOW() - 1 hour
+| WHERE level == "error"
+| STATS count = COUNT(*) BY host.name
+
+// Less efficient - filtering after processing
+FROM logs-*
+| STATS count = COUNT(*) BY host.name, level
+| WHERE level == "error"
+```
+
+### 2. Use Appropriate Time Ranges
+
+Smaller time ranges = faster queries:
+
+```esql
+// Specific range is faster
+| WHERE @timestamp > NOW() - 1 hour
+
+// Than scanning all data
+// (no time filter)
+```
+
+### 3. Limit Fields
+
+Only keep fields you need:
+
+```esql
+// Good - specific fields
+| KEEP @timestamp, message, host.name
+
+// Less efficient - all fields
+// (no KEEP command)
+```
+
+### 4. Use LIMIT
+
+Prevent returning excessive rows:
+
+```esql
+| LIMIT 100  // Always include for raw data queries
+```
+
+---
+
+## Common Query Templates
+
+### Error Investigation
+
+```esql
+FROM logs-*
+| WHERE @timestamp > NOW() - 1 hour
+| WHERE level == "error"
+| KEEP @timestamp, message, host.name, service.name, error.message
+| SORT @timestamp DESC
+| LIMIT 100
+```
+
+### Service Health Overview
+
+```esql
+FROM metrics-*
+| WHERE @timestamp > NOW() - 15 minutes
+| STATS
+    avg_cpu = AVG(system.cpu.percent),
+    avg_mem = AVG(system.memory.used.pct),
+    host_count = COUNT_DISTINCT(host.name)
+  BY service.name
+| SORT avg_cpu DESC
+```
+
+### API Performance Analysis
+
+```esql
+FROM apm-*
+| WHERE @timestamp > NOW() - 1 hour
+| STATS
+    count = COUNT(*),
+    avg_duration = AVG(transaction.duration.us),
+    p95_duration = PERCENTILE(transaction.duration.us, 95),
+    error_count = COUNT(CASE(transaction.result != "success", 1, null))
+  BY transaction.name
+| EVAL error_rate = ROUND(error_count * 100.0 / count, 2)
+| SORT count DESC
+| LIMIT 20
+```
+
+### Traffic Analysis
+
+```esql
+FROM web-logs
+| WHERE @timestamp > NOW() - 24 hours
+| STATS
+    requests = COUNT(*),
+    unique_ips = COUNT_DISTINCT(client.ip)
+  BY hour = DATE_TRUNC(1 hour, @timestamp)
+| SORT hour DESC
+```
+
+### Security Event Review
+
+```esql
+FROM security-*
+| WHERE @timestamp > NOW() - 24 hours
+| WHERE event.category == "authentication"
+| WHERE event.outcome == "failure"
+| STATS
+    failures = COUNT(*)
+  BY user.name, source.ip
+| WHERE failures > 5
+| SORT failures DESC
+```
+
+---
+
+## Handling Ambiguity
+
+When the user request is ambiguous:
+
+### Missing Index
+
+If no index specified, make a reasonable assumption:
+
+- "show errors" → `FROM logs-*`
+- "show CPU usage" → `FROM metrics-*`
+- "show requests" → `FROM web-logs` or `FROM access-*`
+
+Or output the query with a placeholder and note:
+
+```esql
+FROM <index-pattern>  // Specify your index
+| WHERE ...
+```
+
+### Missing Time Range
+
+Add a sensible default:
+
+```esql
+| WHERE @timestamp > NOW() - 24 hours  // Default: last 24 hours
+```
+
+### Unclear Aggregation
+
+When "show X" could mean list or count:
+
+- If followed by "by Y" → aggregation
+- If asking for specifics → raw data
+- If asking "how many" → count
+- Default to raw data with limit
+
+### Unknown Field Names
+
+If field names are uncertain:
+
+1. Use common ECS names as first guess
+2. Suggest running schema discovery
+3. Note the assumption in output
+
+---
+
+## Output Formatting Suggestions
+
+When presenting generated queries:
+
+```
+=== ES|QL Query ===
+
+FROM logs-*
+| WHERE @timestamp > NOW() - 1 hour
+| WHERE level == "error"
+| STATS count = COUNT(*) BY host.name
+| SORT count DESC
+| LIMIT 10
+
+=== Explanation ===
+- Queries all log indices
+- Filters to the last hour
+- Counts errors per host
+- Returns top 10 hosts by error count
+
+=== To Execute ===
+./esql.js raw "FROM logs-* | WHERE @timestamp > NOW() - 1 hour | WHERE level == \"error\" | STATS count = COUNT(*) BY host.name | SORT count DESC | LIMIT 10"
+```

--- a/dashboards/skills/iptv-data-model.md
+++ b/dashboards/skills/iptv-data-model.md
@@ -1,0 +1,208 @@
+# IPTV-Proxy Elasticsearch Data Model
+
+Field reference for all Elasticsearch indices written by iptv-proxy2. Use this when writing ES|QL queries or Lens aggregations in Kibana dashboards.
+
+> **Index prefix:** The default prefix is `iptv`. If the proxy was started with `--es-index-prefix myprefix`, replace `iptv` with `myprefix` in all index names below.
+
+---
+
+## `{prefix}.sessions` — Session lifecycle events
+
+**Type:** Regular data stream (not TSDB)
+**Purpose:** Every session event — start, end, and error — is written here.
+
+### Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `@timestamp` | date | When the event was recorded |
+| `event_kind` | keyword | `session_start`, `session_end`, or `session_error` |
+| `session_id` | keyword | UUID identifying the session across events |
+| `duration_seconds` | long | Filled on `session_end` — watch time in seconds |
+| `bytes_transferred` | long | Filled on `session_end` — bytes proxied |
+| `client_ip` | keyword | IP address of the streaming client |
+| `user_agent` | keyword | HTTP User-Agent header sent by the client |
+| `error_message` | text | Filled on `session_error` — error description |
+| `channel_id` | keyword | Unique channel identifier |
+| `channel_name` | keyword | Human-readable channel name |
+| `channel_group` | keyword | Channel group/category |
+| `channel_type` | keyword | `live`, `movie`, or `series` |
+| `channel_stream_id` | keyword | Provider stream ID |
+| `user_name` | keyword | Authenticated proxy user |
+| `proxy_mode` | keyword | `m3u` or `xtream` |
+
+### Common ES|QL patterns
+
+```esql
+# Active sessions right now
+FROM iptv.sessions
+| WHERE @timestamp > NOW() - 5 minutes AND event_kind == "session_start"
+| STATS active = COUNT(DISTINCT session_id)
+
+# Sessions started over time
+FROM iptv.sessions
+| WHERE event_kind == "session_start"
+| STATS sessions = COUNT(*) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)
+| SORT time_bucket ASC
+
+# Error rate by channel
+FROM iptv.sessions
+| WHERE event_kind IN ("session_end", "session_error")
+| STATS
+    total = COUNT(*),
+    errors = COUNT(*) WHERE event_kind == "session_error"
+  BY channel_name
+| EVAL error_rate_pct = ROUND(errors * 100.0 / total, 1)
+| SORT errors DESC
+```
+
+---
+
+## `{prefix}.user_history` — Completed sessions per user
+
+**Type:** Regular data stream (not TSDB)
+**Purpose:** One document per completed session. Use for user-level analytics and leaderboards. Populated on `session_end`.
+
+### Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `@timestamp` | date | Session start time |
+| `session_id` | keyword | UUID of the session |
+| `session_end_time` | date | When the session ended |
+| `duration_seconds` | long | Watch time in seconds |
+| `bytes_transferred` | long | Bytes proxied |
+| `channel_id` | keyword | Unique channel identifier |
+| `channel_name` | keyword | Human-readable channel name |
+| `channel_group` | keyword | Channel group/category |
+| `channel_type` | keyword | `live`, `movie`, or `series` |
+| `channel_stream_id` | keyword | Provider stream ID |
+| `user_name` | keyword | Authenticated proxy user |
+| `client_ip` | keyword | IP of the streaming client |
+| `user_agent` | keyword | HTTP User-Agent header |
+| `proxy_mode` | keyword | `m3u` or `xtream` |
+
+### Common ES|QL patterns
+
+```esql
+# User leaderboard — top watchers by total hours
+FROM iptv.user_history
+| STATS
+    sessions = COUNT(*),
+    total_hours = SUM(duration_seconds) / 3600.0,
+    total_gb = SUM(bytes_transferred) / 1073741824.0,
+    unique_channels = COUNT_DISTINCT(channel_id)
+  BY user_name
+| SORT total_hours DESC
+| LIMIT 20
+
+# Per-user channel preferences — top channels per user
+FROM iptv.user_history
+| STATS watch_hours = SUM(duration_seconds) / 3600.0 BY user_name, channel_name
+| SORT watch_hours DESC
+
+# Viewing heatmap — activity by hour of day × day of week
+FROM iptv.user_history
+| EVAL hour_of_day = DATE_EXTRACT("hour", @timestamp)
+| EVAL day_of_week = DATE_EXTRACT("day_of_week", @timestamp)
+| STATS sessions = COUNT(*) BY hour_of_day, day_of_week
+| SORT day_of_week ASC, hour_of_day ASC
+
+# Recent sessions across all users
+FROM iptv.user_history
+| KEEP @timestamp, user_name, channel_name, channel_group, duration_seconds, bytes_transferred
+| SORT @timestamp DESC
+| LIMIT 50
+```
+
+---
+
+## `metrics-{prefix}.channel_metrics` — Per-channel per-minute aggregates
+
+**Type:** TSDB data stream (`index.mode: time_series`)
+**Purpose:** Pre-aggregated channel metrics written every minute. Suitable for efficient time-series charts with TSDB `TS` queries and `RATE()`.
+
+> **Important:** Because this is a TSDB index, use the `TS` source command (Elasticsearch 9.2+) for counter fields. For Kibana 8.x use `FROM` with `MAX()` on gauge fields.
+
+### Dimensions (uniquely identify a time series)
+
+| Field | Type | Description |
+|---|---|---|
+| `channel_id` | keyword | Unique channel identifier |
+| `channel_name` | keyword | Human-readable channel name |
+| `channel_group` | keyword | Channel group/category |
+| `channel_type` | keyword | `live`, `movie`, or `series` |
+
+### Gauge metrics (point-in-time values)
+
+| Field | Type | Description |
+|---|---|---|
+| `session_count` | long (gauge) | Sessions started in this minute |
+| `active_sessions` | long (gauge) | Currently active sessions |
+| `unique_users` | long (gauge) | Distinct users watching in this minute |
+
+### Counter metrics (monotonically increasing totals)
+
+| Field | Type | Description |
+|---|---|---|
+| `total_duration_seconds` | long (counter) | Cumulative watch seconds |
+| `bytes_transferred` | long (counter) | Cumulative bytes proxied |
+| `error_count` | long (counter) | Cumulative stream errors |
+
+### Common ES|QL patterns
+
+```esql
+# Top channels by concurrent viewers (Kibana 8.x — gauge via FROM)
+FROM metrics-iptv.channel_metrics
+| STATS max_viewers = MAX(active_sessions) BY channel_name
+| SORT max_viewers DESC
+| LIMIT 10
+
+# Channel activity timeline — active sessions over time (Kibana 8.x)
+FROM metrics-iptv.channel_metrics
+| STATS viewers = MAX(active_sessions) BY
+    time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend),
+    channel_name
+| SORT time_bucket ASC
+
+# Group distribution — total watch time by channel group (Kibana 8.x)
+FROM metrics-iptv.channel_metrics
+| STATS total_hours = SUM(total_duration_seconds) / 3600.0 BY channel_group
+| SORT total_hours DESC
+
+# Bandwidth over time (Kibana 8.x)
+FROM metrics-iptv.channel_metrics
+| STATS total_gb = SUM(bytes_transferred) / 1073741824.0 BY
+    time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)
+| SORT time_bucket ASC
+
+# Error rate per channel using TSDB RATE() (Elasticsearch 9.2+)
+TS metrics-iptv.channel_metrics
+| STATS error_rate = SUM(RATE(error_count)) BY
+    time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), channel_name
+| SORT time_bucket ASC
+```
+
+---
+
+## Index naming quick reference
+
+| Index | Purpose | Default name |
+|---|---|---|
+| Sessions stream | All session events | `iptv.sessions` |
+| User history | Completed sessions | `iptv.user_history` |
+| Channel metrics | TSDB per-minute aggregates | `metrics-iptv.channel_metrics` |
+
+Substitute `iptv` with `--es-index-prefix` value if non-default.
+
+---
+
+## Recommended dashboard data sources
+
+| Dashboard need | Best index | Why |
+|---|---|---|
+| Current active streams | `{prefix}.sessions` | Real-time `session_start` events |
+| User leaderboard / history | `{prefix}.user_history` | Pre-joined per-session records |
+| Channel timelines, trends | `metrics-{prefix}.channel_metrics` | Efficient TSDB aggregates |
+| Error analysis | `{prefix}.sessions` | Has `error_message` text field |
+| Per-user filters, controls | `{prefix}.user_history` | `user_name` keyword field |

--- a/dashboards/skills/kb-dashboard-cli-usage.md
+++ b/dashboards/skills/kb-dashboard-cli-usage.md
@@ -1,0 +1,373 @@
+# Dashboard Compiler CLI
+
+The `kb-dashboard` CLI tool allows you to compile YAML dashboard configurations to Kibana's NDJSON format and optionally upload them directly to Kibana.
+
+## Prerequisites
+
+- **[uv](https://github.com/astral-sh/uv)** (recommended) - Enables running the CLI via `uvx` with zero setup
+- Or **Python 3.12+** with pip for traditional installation
+
+**Note:** When using `uvx`, Python and all dependencies are handled automatically. The VS Code Extension does not require Python either - it includes a bundled binary. See [VS Code Extension Documentation](vscode-extension.md) for zero-configuration setup.
+
+## When to Use the CLI
+
+**Use the CLI when:**
+
+- ✅ Building CI/CD pipelines for dashboard deployment
+- ✅ Batch processing multiple dashboards
+- ✅ Scripting dashboard generation (e.g., templates, dynamic data)
+- ✅ Integrating with other automation tools
+- ✅ Running in headless/server environments without GUI
+- ✅ Using Docker containers or serverless functions
+
+**Use the VS Code Extension when:**
+
+- ✅ Developing dashboards interactively
+- ✅ Learning the YAML schema
+- ✅ Making frequent visual adjustments
+- ✅ Needing live preview and validation
+
+**See:** [VS Code Extension Documentation](vscode-extension.md) for interactive development workflow.
+
+---
+
+## Installation
+
+### Using uvx (Recommended)
+
+Run the CLI directly without cloning or installing anything:
+
+```bash
+uvx kb-dashboard-cli compile --help
+```
+
+This downloads and runs the published package automatically. No Python environment setup required!
+
+### Development Installation
+
+For contributors or development workflows, clone the repository:
+
+```bash
+git clone https://github.com/strawgate/kb-yaml-to-lens
+cd kb-yaml-to-lens
+make cli install
+```
+
+See [DEVELOPING.md](https://github.com/strawgate/kb-yaml-to-lens/blob/main/DEVELOPING.md) for full development setup.
+
+## Basic Usage
+
+### Compile Dashboards
+
+Compile YAML dashboards to NDJSON format:
+
+```bash
+uvx kb-dashboard-cli compile
+```
+
+This will:
+
+- Find all YAML files in `inputs/` (by default)
+- Compile them to Kibana JSON format
+- Output NDJSON files to `output/` directory
+- Create individual NDJSON files per scenario
+- Create a combined `compiled_dashboards.ndjson` file
+
+### Compile a Single File
+
+Compile a specific YAML file without scanning a directory:
+
+```bash
+uvx kb-dashboard-cli compile --input-file ./dashboards/example.yaml
+```
+
+When `--input-file` is provided, `--input-dir` is ignored.
+
+### Export Individual JSON Files
+
+For workflows that require individual JSON files per dashboard (e.g., Fleet integration):
+
+```bash
+uvx kb-dashboard-cli compile --format json --output-dir ./output
+```
+
+This will:
+
+- Create one pretty-printed JSON file per dashboard
+- Name files based on the dashboard title (sanitized for filesystem safety)
+
+### CI Sync Detection
+
+Use the `--exit-non-zero-on-change` flag to detect when YAML and JSON files are out of sync in CI pipelines:
+
+```bash
+uvx kb-dashboard-cli compile --format json --output-dir ./dashboards --exit-non-zero-on-change
+if [ $? -ne 0 ]; then
+    echo "Dashboard JSON files are out of sync with YAML sources"
+    exit 1
+fi
+```
+
+When this flag is enabled, the exit code equals the number of files that changed (capped at 125). By default, the command exits with code 0 on success regardless of whether files changed.
+
+### Compile and Upload to Kibana
+
+Compile dashboards and upload them directly to Kibana:
+
+```bash
+uvx kb-dashboard-cli compile --upload
+```
+
+This will compile the dashboards and upload them to a local Kibana instance.
+
+### Screenshot Dashboards
+
+Generate a PNG screenshot of a dashboard:
+
+```bash
+uvx kb-dashboard-cli screenshot --dashboard-id <id> --output <file.png>
+```
+
+This will use Kibana's Reporting API to take a screenshot.
+
+### Export Dashboard for Issue
+
+Export a dashboard from Kibana and create a pre-filled GitHub issue:
+
+```bash
+uvx kb-dashboard-cli export-for-issue --dashboard-id <id>
+```
+
+This will export the dashboard and open your browser with a pre-filled GitHub issue containing the dashboard JSON.
+
+### Disassemble Dashboards
+
+Break down a Kibana dashboard JSON into components for easier LLM-based conversion:
+
+```bash
+uvx kb-dashboard-cli disassemble dashboard.ndjson -o output_dir
+```
+
+This will extract the dashboard into separate files:
+
+- `metadata.json` - Dashboard metadata (id, title, description, version)
+- `options.json` - Dashboard display options
+- `controls.json` - Control group configuration
+- `filters.json` - Dashboard-level filters
+- `references.json` - Data view references
+- `panels/` - Individual panel JSON files
+
+For a comprehensive guide on using this tool to convert dashboards from JSON to YAML, see the [Dashboard Decompiling Guide](dashboard-decompiling-guide.md).
+
+## Configuration
+
+### Environment Variables
+
+The CLI supports configuration via environment variables:
+
+```bash
+export KIBANA_URL=http://localhost:5601
+export KIBANA_USERNAME=elastic
+export KIBANA_PASSWORD=changeme
+export KIBANA_SPACE_ID=my-space  # Optional: target a specific Kibana space
+# OR use API key instead
+export KIBANA_API_KEY=your-api-key-here
+```
+
+Then simply run:
+
+```bash
+uvx kb-dashboard-cli compile --upload
+```
+
+### Command-Line Options
+
+All options can also be specified on the command line:
+
+```bash
+uvx kb-dashboard-cli compile \
+  --upload \
+  --kibana-url http://localhost:5601 \
+  --kibana-username elastic \
+  --kibana-password changeme
+```
+
+To upload to a specific Kibana space:
+
+```bash
+uvx kb-dashboard-cli compile --upload --kibana-space-id production
+```
+
+Or with environment variables:
+
+```bash
+export KIBANA_SPACE_ID=staging
+uvx kb-dashboard-cli compile --upload
+```
+
+## Command Reference
+
+The following commands are available in the `kb-dashboard` CLI. For detailed information about each command and its options, see the auto-generated reference below.
+
+::: mkdocs-click
+    :module: dashboard_compiler.cli
+    :command: cli
+    :prog_name: kb-dashboard
+    :depth: 2
+    :style: table
+
+## Makefile Shortcuts (Development)
+
+For contributors working from a cloned repository, the project includes convenient Makefile targets:
+
+```bash
+# Compile only
+make cli compile
+
+# Compile and upload (uses environment variables for Kibana config)
+make cli upload
+```
+
+See [DEVELOPING.md](https://github.com/strawgate/kb-yaml-to-lens/blob/main/DEVELOPING.md) for the full development workflow.
+
+## Authentication
+
+The CLI supports two authentication methods:
+
+### Basic Authentication
+
+Use username and password:
+
+```bash
+uvx kb-dashboard-cli compile \
+  --upload \
+  --kibana-username elastic \
+  --kibana-password changeme
+```
+
+Or via environment variables:
+
+```bash
+export KIBANA_USERNAME=elastic
+export KIBANA_PASSWORD=changeme
+uvx kb-dashboard-cli compile --upload
+```
+
+### API Key Authentication
+
+Use a Kibana API key:
+
+```bash
+uvx kb-dashboard-cli compile \
+  --upload \
+  --kibana-api-key "your-base64-encoded-key"
+```
+
+Or via environment variable:
+
+```bash
+export KIBANA_API_KEY="your-base64-encoded-key"
+uvx kb-dashboard-cli compile --upload
+```
+
+To create an API key in Kibana:
+
+1. Go to Stack Management → API Keys
+2. Click "Create API key"
+3. Give it a name and set appropriate privileges
+4. Copy the encoded key and use it with the CLI
+
+## Troubleshooting
+
+### Connection Refused
+
+If you get a connection refused error:
+
+- Verify Kibana is running: `curl http://localhost:5601/api/status`
+- Check the Kibana URL is correct
+- Ensure there are no firewall rules blocking the connection
+
+### Authentication Failed
+
+If you get authentication errors:
+
+- Verify your credentials are correct
+- Check that the user has appropriate permissions
+- For API keys, ensure the key hasn't expired
+
+### Upload Errors
+
+If objects fail to upload:
+
+- Check the Kibana logs for detailed error messages
+- Verify the NDJSON format is valid
+- Use `--no-overwrite` if you want to preserve existing objects
+
+---
+
+## Dashboard Linter CLI
+
+The `kb-dashboard-lint` CLI tool checks YAML dashboard configurations for best practices and common issues.
+
+### Basic Usage
+
+Check a single dashboard file:
+
+```bash
+uvx kb-dashboard-lint check --input-file ./dashboards/example.yaml
+```
+
+Check all dashboards in a directory:
+
+```bash
+uvx kb-dashboard-lint check --input-dir ./dashboards
+```
+
+### Severity Levels
+
+The linter reports issues at three severity levels:
+
+| Level | Description |
+| ----- | ----------- |
+| **error** | Critical issues that should be fixed |
+| **warning** | Problems that may affect usability |
+| **info** | Suggestions for improvement |
+
+By default, the linter exits with code 0 for info-only results. Use `--severity-threshold` to fail on warnings:
+
+```bash
+uvx kb-dashboard-lint check --input-file dashboard.yaml --severity-threshold warning
+```
+
+### List Available Rules
+
+See all lint rules and their descriptions:
+
+```bash
+uvx kb-dashboard-lint list-rules
+```
+
+### Configuration
+
+Create a `.dashboard-lint.yaml` file to customize rule behavior:
+
+```bash
+uvx kb-dashboard-lint check --config .dashboard-lint.yaml
+```
+
+### Output Formats
+
+Get machine-readable output for CI integration:
+
+```bash
+uvx kb-dashboard-lint check --input-dir ./dashboards --format json
+```
+
+### Linter Command Reference
+
+::: mkdocs-click
+    :module: dashboard_lint.cli
+    :command: cli
+    :prog_name: kb-dashboard-lint
+    :depth: 2
+    :style: table

--- a/dashboards/skills/kibana-dashboard-style-guide.md
+++ b/dashboards/skills/kibana-dashboard-style-guide.md
@@ -1,0 +1,480 @@
+# Kibana Dashboard Style Guide
+
+**Based on:** Analysis of Elastic Integrations repository dashboards
+**Last Updated:** 2026-01-09
+**Version:** 2.0
+
+---
+
+## Introduction
+
+This guide documents best practices for designing Kibana dashboards, derived from analysis of 49 production dashboards across 37 Elastic integration packages. Follow these conventions to create dashboards that are consistent, intuitive, and effective for dashboard creators using kb-yaml-to-lens, teams standardizing dashboard design, and anyone building Kibana dashboards for Elastic integrations.
+
+### Key Principles
+
+1. **Predictable Organization** - Users navigate any dashboard using the same mental model
+2. **Visualization Clarity** - Choose chart types based on data characteristics, not aesthetics
+3. **Progressive Disclosure** - Flow from overview to detail (metrics → charts → tables)
+4. **Functional Minimalism** - Every panel serves a purpose; avoid decorative elements
+5. **Consistent Conventions** - Follow patterns for naming, sizing, and positioning
+
+---
+
+## Dashboard Structure
+
+### Standard Layout Hierarchy
+
+All dashboards follow this top-to-bottom structure:
+
+1. **Context Layer** - Navigation, title, description
+2. **Summary Layer** - Key metrics and KPIs
+3. **Analysis Layer** - Charts and visualizations
+4. **Detail Layer** - Data tables for drill-down
+
+### Grid Layout (48-Column System)
+
+Kibana uses a 48-column grid with standard panel widths:
+
+| Panel Type | Width (columns) | Use Case |
+| ---------- | --------------- | -------- |
+| Full-width markdown | 48 | Navigation, section headers |
+| Single metric card | 8-12 | Individual KPIs |
+| Small chart | 12-16 | Pie/donut charts |
+| Medium chart | 24 | Half-width time series |
+| Full chart | 48 | Primary time series, maps |
+| Data table | 48 | Detail drill-down |
+
+Arrange charts in horizontal rows of 2-3 panels for easy comparison.
+
+---
+
+## Naming Conventions
+
+### Dashboard Titles
+
+**Format:** `[Category PackageName] Specific Focus`
+
+**Generic Examples:**
+
+- `[Logs WebServer] Access and error logs`
+- `[Metrics Application] Heap`
+- `[Logs Firewall] Connection analysis`
+- `[Security EmailGateway] Threat detection`
+
+**Category Prefixes:**
+
+- `[Logs ...]` - Log analysis dashboards
+- `[Metrics ...]` - Performance/metric dashboards
+- `[Traces ...]` - APM trace dashboards
+- Package name without prefix - When it's the only dashboard type
+
+### Panel Titles
+
+**Guidelines:**
+
+- Be concise and descriptive
+- Avoid redundant prefixes like "Chart of" or "Graph of"
+- Include the dimension when relevant (e.g., "by Time", "by Category")
+
+**Effective Examples:**
+
+- "Socket Syscalls Time Series"
+- "Top 10 Malware Threats"
+- "Browsers Breakdown"
+- "Response Codes Over Time"
+
+---
+
+## Visualization Selection
+
+### Decision Framework
+
+| Data Characteristic | Visualization | Example Use Case |
+| ------------------- | ------------- | ---------------- |
+| Single KPI/Count | Metric Card | Total Requests, Active Users |
+| Categorical Proportions | Pie/Donut Chart | File types, browsers, protocols |
+| Categorical Ranking (short labels) | Vertical Bar Chart | Category comparison |
+| Categorical Ranking (long labels) | Horizontal Bar Chart | Top users, top URLs, top regions |
+| Time Series - Event counts | Stacked Area Chart | Events by type over time |
+| Time Series - Discrete events | Stacked Bar Chart | HTTP status codes over time |
+| Time Series - Continuous metrics | Line Chart | Memory usage, CPU utilization |
+| Hierarchical Categories | Treemap | Event categories with subcategories |
+| Bounded Metrics (0-100%) | Gauge Chart | Memory usage %, disk capacity % |
+| Performance Percentiles | Heatmap | 95th percentile latency over time |
+| Top N with Details | Data Table | Top 10 threats with counts |
+| Recent Events/Logs | Data Table | Audit logs, access logs |
+| Geographic Distribution | Map | Access by country, network sources |
+
+---
+
+## Visualization Guidelines
+
+Complete configuration details are available in [Lens Panel Configuration](panels/lens.md).
+
+### Metric Cards
+
+**When to Use:** High-level KPIs, single counts, status breakdowns at dashboard top.
+
+**Best Practices:** Use sparingly (0-4 typical, 78% use zero). Group horizontally, position before detailed visualizations. Modern dashboards prefer charts over standalone metrics. When the `primary_label` text matches or closely resembles the panel `title`, set `hide_title: true` to avoid displaying redundant text.
+
+```yaml
+- title: Total Requests
+  hide_title: true  # primary_label "Requests" conveys the same meaning as the title
+  lens:
+    type: metric
+    metric:
+      primary_label: "Requests"
+```
+
+### Pie and Donut Charts
+
+**When to Use:** Proportional distribution, "Top N" breakdowns (file types, browser/OS, protocols, event categories).
+
+**Best Practices:** Show top 5-10 categories as percentages, prefer donut over pie, width 12-16 columns.
+
+### Time Series Charts (XY Charts)
+
+**Area Charts** (Most Common):
+
+- Event frequency over time, volume trends
+- Stacking shows categorical breakdown while maintaining total volume
+- Filled area indicates volume
+
+**Line Charts:**
+
+- Precise metric tracking, performance monitoring
+- Memory usage, CPU metrics, latency
+- Dual-axis for comparing different metric scales
+
+**Bar Charts:**
+
+- Discrete time-bucketed events
+- HTTP responses, error counts
+- Stacking shows status code or category distribution
+
+**Best Practices:**
+
+- Use automatic time interval binning
+- Add legends on the right side
+- Stack when showing categorical breakdowns
+- Use 30-day moving averages for smoothing trends (performance dashboards)
+
+**ES|QL Breakdown Labels:** ES|QL charts support only one breakdown field, but you can concatenate multiple dimensions into a single breakdown label:
+
+```esql
+# Concatenate multiple dimensions for richer breakdown labels
+TS metrics-*
+|| STATS cpu_usage = AVG(container.cpu.utilization) / 100
+  BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend),
+     container.id, container.name, cpu_mode
+|| EVAL container_id_short = SUBSTRING(TO_STRING(container.id), 0, 6)
+|| EVAL breakdown_label = CONCAT(cpu_mode, " - ", container.name, " - ", container_id_short)
+|| STATS cpu_usage = AVG(cpu_usage) BY time_bucket, breakdown_label
+```
+
+This pattern is especially useful for detailed charts showing multiple dimensions (e.g., "kernelmode - mycontainer - abc123").
+
+### Data Tables
+
+**When to Use:** Detail drill-down, "Top N" lists, searchable log/event details.
+
+**Best Practices:** Position at bottom (~60% preference) or intermixed with charts (security/log dashboards). Use 10 rows/page, sort by count descending, 3-6 columns for summaries. Column layout: count/frequency + primary dimension + secondary dimensions (who, where, when).
+
+### Bar Charts (Non-Time-Series)
+
+**Horizontal:** Long labels (URLs, usernames, regions), percentile distributions, better text readability.
+
+**Vertical:** Short category labels, standard comparisons, stacking more common.
+
+### Maps
+
+**Point-Based:** Plot IP addresses/coordinates, security context, user access patterns. Panel type: `map`. Usage: 30% of dashboards.
+
+**Choropleth:** Country/region-level aggregations, administrative boundaries. Visualization type: `lnsChoropleth`. Color intensity represents metric values.
+
+### Treemap Charts
+
+**When to Use:** Hierarchical categorical data (firewall events, network protocols, file systems, security classification).
+
+**Best Practices:** Show parent-child category structure with proportions at each level. Effective for network/security dashboards.
+
+### Heatmap Charts
+
+**When to Use:** Performance analysis, percentile tracking (95th/99th), latency distributions, multi-dimensional correlations.
+
+**Best Practices:** Combine time with categorical dimension. Common for request duration, response sizes, query performance, API latency by region/endpoint.
+
+### Gauge Charts
+
+**When to Use:** Bounded metrics (0-100%), utilization/capacity indicators (memory, disk, connection pools, cache hit rate, thread pools).
+
+**Best Practices:** Clear min/max bounds, visual arc indicator, position in summary layer, limit to 3-6 per dashboard.
+
+---
+
+## Dashboard Components
+
+### Markdown Panels
+
+**Purpose:** Navigation and context.
+
+**Positioning:** Always at the top.
+
+**When to Use:**
+
+- Standard for multi-dashboard packages (3+ dashboards)
+- Position at top-left (x: 0, y: 0)
+- Typical width: 10-18 columns for navigation, 48 columns for section headers
+
+**Content Types:**
+
+1. **Navigation Links** (Most Common)
+   - Links to related dashboards in the package
+   - Table of contents for multi-dashboard sets
+   - Header: "Navigation" or "Table of Contents"
+   - Bulleted list of dashboard links
+
+2. **Section Headers**
+   - Visual separation between dashboard areas
+   - Use sparingly
+
+3. **Context Information**
+   - Brief explanations when title isn't self-explanatory
+
+Single-purpose dashboards may omit navigation, but multi-dashboard packages should consistently provide navigation links for discoverability.
+
+### Links Panels
+
+For packages with multiple dashboards, links panels provide an alternative to markdown navigation. Pattern observed in 16% of multi-dashboard packages. Position at top with standard 12-column width.
+
+### Control Filters
+
+**Usage Pattern:** Control filters ARE used in approximately 25% of Elastic integration dashboards when multi-dimensional filtering adds value.
+
+**Common Types:**
+
+- Options list (dropdown selections)
+- Range slider (numeric/date ranges)
+- Hierarchical controls (nested categories)
+
+**Positioning:** Top of dashboard after navigation
+
+**When to Use:**
+
+- Multi-tenant scenarios (filter by host, service, user)
+- Complex dashboards requiring dynamic filtering across multiple dimensions
+- Security dashboards with varied analysis perspectives
+
+**Alternative Filtering Approaches:**
+
+- Time picker (global time range selection)
+- Dashboard-level filters (data stream, package filters)
+- Panel-level filters (specific to individual visualizations)
+
+---
+
+## Filters and Queries
+
+### Global Dashboard Filters
+
+**Standard Pattern:** Filter by dataset using KQL syntax.
+
+Single dataset:
+
+```yaml
+filters:
+  - equals: package.dataset_name
+    field: data_stream.dataset
+```
+
+Multiple datasets:
+
+```yaml
+filters:
+  - query: "data_stream.dataset: (webserver.access OR webserver.error)"
+```
+
+### Panel-Level Filters
+
+**Common Patterns:** Event type/category filters, status code filters, field existence checks.
+
+Example:
+
+```yaml
+filters:
+  - equals: connection
+    field: event.type
+  - equals: bind
+    field: auditd.data.syscall
+  - query: "NOT auditd.data.addr: netlink"
+```
+
+### Query Language
+
+**Standard:** Use KQL (Kibana Query Language) for consistency.
+
+---
+
+## Color and Styling
+
+### Color Schemes
+
+Use Kibana's default color palette. Avoid custom color overrides (use sparingly) and too many colors (limit to 5-10 categories).
+
+### Legend Positioning
+
+**Standard:** Right-side placement
+**Exception:** Bottom placement when charts are narrow
+
+### Number Formatting
+
+| Data Type | Format | Example |
+| --------- | ------ | ------- |
+| Bytes | 2 decimal precision | 1.23 GB |
+| Counts | Integer | 1,234 |
+| Percentages | Display on pie/donut | 45.2% |
+| Dates | ISO format | 2024-01-15T10:30:00Z |
+
+---
+
+## Dashboard Types and Patterns
+
+### Security Dashboards
+
+Heavy use of categorical breakdowns (pie/donut charts), focus on "Top N" patterns (threats, users, actions), data tables for audit trails, control filters for multi-tenant scenarios.
+
+**Flow:** Navigation → Controls → Events over time → Event categories → Top users/actions → Audit log
+
+### Performance Dashboards
+
+Exclusive use of line charts for precision, dual-axis comparisons, moving averages for smoothing. No pie charts (metrics don't have categorical proportions).
+
+**Flow:** Navigation → Control → CPU/Memory over time → GC activity/Thread count → Latency/Throughput
+
+### Infrastructure Dashboards
+
+Mix of metrics, time series, and categorical breakdowns. Geographic maps when relevant, browser/OS distribution analysis, error rate and status code tracking.
+
+**Flow:** Navigation → Metrics → Geographic distribution → Requests over time → Status codes → Browser/OS → Top URLs table
+
+### Dashboard Complexity Spectrum
+
+| Complexity | Panels | Viz Types | Panel Mix | Use Cases |
+| ---------- | ------ | --------- | --------- | --------- |
+| **Simple** | 3-6 | 1-2 | 0-2 metrics, 2-4 charts, 0-1 tables | Specialized performance tracking, single-service monitoring |
+| **Standard** | 7-12 | 3-4 | 2-4 metrics, 4-6 charts, 1-2 tables | General-purpose monitoring, package overviews |
+| **Complex** | 13+ | 5-6 | 3-6 metrics, 7-12 charts, 2-4 tables, controls | Enterprise monitoring, multi-dimensional analysis, security operations |
+
+**Complex dashboard considerations:** Use markdown sections to separate areas, group related visualizations, maintain logical vertical flow. Consider breaking into multiple dashboards if exceeding 20 panels.
+
+---
+
+## Time Configuration
+
+### Time Range
+
+**Default Ranges:**
+
+- Infrastructure monitoring: 15 minutes
+- Security dashboards: User-selected (flexible)
+- Performance monitoring: 1 hour to 24 hours
+
+Enable time range restoration as best practice.
+
+### Time Synchronization
+
+**Standard:** Enable cursor synchronization across time-series panels.
+
+```yaml
+sync_cursor: true
+sync_tooltips: false
+```
+
+---
+
+## Accessibility and Usability
+
+### Panel Sizing
+
+**Minimum Heights:**
+
+- Metric cards: 4 grid units
+- Charts: 12-15 grid units
+- Tables: 15-20 grid units (allow for pagination)
+- Markdown headers (at default font_size 12):
+  - Headers h4-h6: 2 grid units
+  - Headers h1-h3: 3 grid units
+  - Header with one line of text below: 5 grid units
+
+### Panel Ordering
+
+**Vertical Flow Best Practices:**
+
+1. Navigation and context (top)
+2. Controls (immediately after navigation, when used)
+3. Key metrics (before detailed charts)
+4. Primary visualizations (middle)
+5. Detail tables (bottom preferred, intermixed when contextually relevant)
+
+### Responsive Considerations
+
+- Avoid panels narrower than 12 columns
+- Test dashboard at different screen sizes
+- Ensure tables have horizontal scroll when needed
+
+---
+
+## Examples and Templates
+
+Reference the `packages/kb-dashboard-docs/content/examples/` directory for complete dashboard examples demonstrating these patterns (aerospike, apache_otel, aws_cloudtrail_otel, crowdstrike, elasticsearch_otel, k8s_cluster_otel, memcached_otel, and more). Templates show navigation panels, metric cards, time series charts, categorical breakdowns, and detail tables in standard configurations.
+
+---
+
+## Checklist
+
+**Structure & Layout:**
+
+- [ ] Title: `[Category Package] Focus` format, description when needed
+- [ ] Hierarchy: context → control → summary → analysis → detail
+- [ ] Navigation at top (multi-dashboard packages), tables at bottom (preferred)
+- [ ] Standard widths (12, 16, 24, 48 columns), min 12 columns, charts 12-15 grid units
+
+**Visualizations:**
+
+- [ ] Chart types match data characteristics (area for events, line for metrics, pie for proportions)
+- [ ] Metric cards: 0-4 per dashboard, pie/donut: top 5-10 only
+- [ ] Specialized: treemap (hierarchical), heatmap (percentiles), gauge (0-100%)
+
+**Naming & Formatting:**
+
+- [ ] Panel titles concise, no redundant prefixes, field labels human-readable
+- [ ] Number formatting appropriate, legends positioned correctly
+
+**Filters & Controls:**
+
+- [ ] Global filter for `data_stream.dataset`, panel filters specific, KQL syntax consistent
+- [ ] Controls used when multi-dimensional filtering adds value
+
+**Configuration & Testing:**
+
+- [ ] Time range appropriate, cursor sync enabled for time-series
+- [ ] Tested at different time ranges, filters work, tables paginate (10 rows), no console errors
+
+---
+
+## Additional Resources
+
+### Related Documentation
+
+- [Dashboard Decompiling Guide](dashboard-decompiling-guide.md) - Converting Kibana JSON to YAML
+- [Panel Types Documentation](panels/base.md) - Detailed panel configuration
+- [Lens Panel Configuration](panels/lens.md) - Complete field descriptions and options
+- [Controls Documentation](controls/config.md) - Dashboard control configuration
+- [Filters Documentation](filters/config.md) - Filter and query configuration
+
+### External Resources
+
+- [Kibana Lens Documentation](https://www.elastic.co/docs/explore-analyze/visualize/lens)
+- [Elastic Common Schema (ECS)](https://www.elastic.co/guide/en/ecs/current/index.html)
+- [Kibana Query Language (KQL)](https://www.elastic.co/docs/explore-analyze/query-filter/languages/kql)
+- [Elasticsearch Query Language (ESQL)](https://www.elastic.co/docs/reference/query-languages/esql)

--- a/dashboards/skills/kibana-dashboard-yaml.md
+++ b/dashboards/skills/kibana-dashboard-yaml.md
@@ -1,0 +1,904 @@
+# Kibana dashboard YAML reference
+
+*(Combined from kb-yaml-to-lens: index, architecture, dashboard-decompiling-guide)*
+
+# YAML ➤ Lens Dashboard Compiler
+
+Convert human-friendly YAML dashboard definitions into Kibana NDJSON format.
+
+![The Chameleon mascot](./images/project-banner-smaller.png)
+
+This tool simplifies the process of creating and managing Kibana dashboards by
+allowing you to define them in a clean, maintainable YAML format instead of
+hand-crafting complex JSON.
+
+## Getting Started
+
+### VS Code Extension (Recommended)
+
+**Best for interactive development** - Live preview, visual editing, built-in snippets
+
+**No Python installation required!** The extension includes a bundled LSP server binary.
+
+**Installation:**
+
+1. **Install the extension:**
+   - **OpenVSX Registry** (Cursor, VS Code forks): Search "Kibana Dashboard Compiler"
+   - **Manual**: Download `.vsix` from [releases](https://github.com/strawgate/kb-yaml-to-lens/releases)
+
+2. **Create your first dashboard:**
+
+   Create a new file called `my-dashboard.yaml` and add the following content:
+
+   ```yaml
+   dashboards:
+   - name: My First Dashboard
+     description: A simple dashboard with markdown
+     panels:
+       - title: Hello Panel
+         markdown:
+           content: |
+             # Hello, Kibana!
+
+             This is my first markdown panel.
+         size: {w: 24, h: 15}
+   ```
+
+   Or use snippets: type `dashboard` and press Tab to insert a template.
+
+3. **Preview your dashboard:**
+   - Save the file (Ctrl+S) to auto-compile
+   - Open Command Palette (Ctrl+Shift+P / Cmd+Shift+P)
+   - Run **"YAML Dashboard: Preview Dashboard"**
+
+4. **Upload to Kibana:**
+   - Configure Kibana URL in VS Code settings
+   - Run **"YAML Dashboard: Open in Kibana"**
+
+**Full guide:** [VS Code Extension Documentation](vscode-extension.md)
+
+---
+
+### CLI (For Automation & Scripting)
+
+**Best for:** CI/CD pipelines, batch processing, programmatic usage
+
+**Requirements:** [uv](https://github.com/astral-sh/uv) (recommended) or Python 3.12+
+
+**Installation:** No clone or setup required! Run directly with uvx:
+
+```bash
+uvx kb-dashboard-cli compile --help
+```
+
+**Your First Dashboard:**
+
+1. Create `inputs/my-dashboard.yaml`:
+
+   ```yaml
+   dashboards:
+   - name: My First Dashboard
+     description: A simple dashboard
+     panels:
+       - title: Welcome
+         size: {w: 24, h: 15}
+         markdown:
+           content: |
+             # Welcome to Kibana!
+   ```
+
+2. Compile:
+
+   ```bash
+   uvx kb-dashboard-cli compile --input-file inputs/my-dashboard.yaml
+   ```
+
+3. Upload to Kibana:
+
+   ```bash
+   uvx kb-dashboard-cli compile --input-file inputs/my-dashboard.yaml --upload --kibana-url http://localhost:5601
+   ```
+
+**Full guide:** [CLI Documentation](CLI.md)
+
+---
+
+## Features
+
+- **YAML-based Definition** – Define dashboards, panels, filters, and queries in simple, readable YAML.
+- **Kibana Integration** – Compile to NDJSON format compatible with Kibana 8+.
+- **Rich Panel Support** – Support for Lens (metric, pie, XY charts), Markdown, Links, Image, and Search panels.
+- **Color Palettes** – Choose from color-blind safe, brand, and other built-in color palettes.
+- **Interactive Controls** – Add options lists, range sliders, and time sliders with chaining support.
+- **Flexible Filtering** – Use a comprehensive filter DSL (exists, phrase, range) or raw KQL/Lucene/ESQL queries.
+- **Direct Upload** – Compile and upload to Kibana in one step, with support for authentication and API keys.
+- **Screenshot Export** – Generate high-quality PNG screenshots of your dashboards programmatically.
+
+## More Examples
+
+### Lens Metric Panel
+
+Here's a dashboard with a Lens metric panel displaying a count:
+
+```yaml
+dashboards:
+- name: Metric Dashboard
+  description: A dashboard with a single metric panel
+  panels:
+    - title: Document Count
+      type: lens
+      size: {w: 24, h: 15}
+      data_view: your-index-pattern-*
+      chart:
+        type: metric
+        metrics:
+          - type: count
+            label: Total Documents
+```
+
+### Programmatic Alternative
+
+While this guide focuses on YAML, you can also create dashboards entirely in Python code. This approach offers:
+
+- Dynamic dashboard generation based on runtime data
+- Type safety with Pydantic models
+- Reusable dashboard templates and components
+- Integration with existing Python workflows
+
+See the [Programmatic Usage Guide](programmatic-usage.md) for examples and patterns.
+
+## Next Steps
+
+### Enhance Your Workflow
+
+- **[VS Code Extension Features](vscode-extension.md)** - Visual grid editor, code snippets, keyboard shortcuts
+- **[CLI Advanced Usage](CLI.md)** - Environment variables, API keys, CI/CD integration
+- **[Dashboard Decompiling Guide](dashboard-decompiling-guide.md)** - Convert existing Kibana JSON dashboards to YAML
+- **[Complete Examples](examples/index.md)** - Production-ready dashboard templates
+
+### User Guide
+
+Reference documentation for YAML dashboard syntax:
+
+- **[Dashboard Configuration](dashboard/dashboard.md)** - Dashboard-level settings and options.
+- **[Panel Types](panels/base.md)** - Available panel types (Markdown, Charts, Images, Links, etc.).
+- **[Dashboard Controls](controls/config.md)** - Interactive filtering controls.
+- **[Filters & Queries](filters/config.md)** - Data filtering and query configuration.
+
+### Developer Guide
+
+Advanced documentation for contributors and programmatic usage:
+
+- **[Architecture Overview](architecture.md)** - Technical design and data flow.
+- **[Programmatic Usage](programmatic-usage.md)** - Using the Python API directly to generate dashboards.
+- **[API Reference](api/index.md)** - Auto-generated Python API documentation.
+- **[Contributing Guide](https://github.com/strawgate/kb-yaml-to-lens/blob/main/CONTRIBUTING.md)** - How to contribute and add new capabilities.
+- **[Kibana Architecture Reference](kibana-architecture.md)** - Understanding Kibana's internal structure.
+
+## How It Works
+
+```mermaid
+graph TB
+    YAML[YAML Definition]
+    KIBANA[Kibana]
+
+    subgraph "Interactive Development"
+        EXT[VS Code Extension]
+        EXT --> PREVIEW[Live Preview]
+    end
+
+    subgraph "Automation/CI"
+        CLI[CLI Compiler]
+        CLI --> NDJSON[NDJSON Files]
+    end
+
+    YAML --> EXT
+    YAML --> CLI
+    EXT --> KIBANA
+    NDJSON --> KIBANA
+```
+
+## License
+
+MIT
+
+### Third-Party Content
+
+Some example dashboards in `packages/kb-dashboard-docs/content/examples/` are derived from the [Elastic integrations repository](https://github.com/elastic/integrations) and are licensed under the [Elastic License 2.0](https://github.com/strawgate/kb-yaml-to-lens/blob/main/licenses/ELASTIC-LICENSE-2.0.txt). Specifically:
+
+- `packages/kb-dashboard-docs/content/examples/system_otel/` - System monitoring dashboards for OpenTelemetry
+- `packages/kb-dashboard-docs/content/examples/docker_otel/` - Docker container monitoring dashboards for OpenTelemetry
+
+See [licenses/README.md](https://github.com/strawgate/kb-yaml-to-lens/blob/main/licenses/README.md) for the complete list of affected files.
+
+## Support
+
+For issues and feature requests, please refer to the repository's issue tracker.
+
+# Dashboard Compiler Architecture
+
+This document describes the architecture of the dashboard compiler, which converts a simplified YAML representation of Kibana dashboards into the complex Kibana dashboard JSON format.
+
+## Goal
+
+The primary goal is to provide a human-readable and maintainable way to define Kibana dashboards using YAML, abstracting away the complexities of the native JSON structure.
+
+## Design
+
+The compiler is designed using a layered approach with distinct components responsible for different stages of the conversion process.
+
+1. **YAML Loading and Parsing:**
+    - The process begins by loading the YAML configuration file.
+    - The `PyYAML` library is used to parse the YAML content into a Python dictionary.
+
+2. **Pydantic Model Representation:**
+    - The codebase uses a three-layer pattern with separate models for input configuration and output views:
+      - **Config Models** (`**/config.py`): Define the YAML schema structure using Pydantic, handling validation and ensuring the parsed YAML conforms to the defined schema. These models use a `BaseCfgModel` base class.
+      - **View Models** (`**/view.py`): Define the Kibana JSON output structure using Pydantic. These models use a `BaseVwModel` base class and include custom serialization logic.
+      - **Compile Functions** (`**/compile.py`): Transform config models into view models, handling the specific formatting and mapping required for each component.
+    - Each major component of a dashboard (Dashboard, Panel, Grid, etc.) and its variations (different panel types, Lens visualizations, dimensions, metrics, etc.) follows this pattern.
+    - A custom validator in the base `Panel` class is used to dynamically instantiate the correct panel subclass based on the `type` field in the YAML data.
+
+3. **Compilation Process:**
+    - Compile functions in `compile.py` files take config model instances and transform them into view model instances.
+    - These functions handle the specific formatting and nesting required for each element (panels, visualizations, layers, etc.).
+    - The top-level dashboard compilation orchestrates the compilation of all components (panels, controls, filters, queries) and assembles the final Kibana JSON structure.
+    - View models use Pydantic's `model_dump_json()` method to serialize to JSON.
+
+4. **ID and Reference Management (Future Enhancement):**
+    - The Kibana dashboard JSON relies heavily on unique IDs and references between components.
+    - A future enhancement will involve implementing a system for generating unique IDs and managing these references during the compilation process to ensure the generated dashboards are valid and functional in Kibana.
+
+5. **Error Handling (Future Enhancement):**
+    - Robust error handling will be added to catch and report issues during YAML parsing, data validation, and JSON compilation.
+
+## Components
+
+The codebase is organized into packages:
+
+**Core Package (`packages/kb-dashboard-core/src/kb_dashboard_core/`):**
+
+- **`dashboard_compiler.py`:** Main entry point containing the core compilation orchestration functions (`load`, `render`, `dump`).
+- **`dashboard/`:** Top-level dashboard compilation with `config.py`, `view.py`, and `compile.py`.
+- **`panels/`:** Panel compilation with subdirectories for each panel type (markdown, links, images, search, charts).
+- **`panels/charts/`:** Chart-specific compilation with subdirectories for different chart types (metric, pie, xy) and components (lens/esql metrics, dimensions, columns).
+- **`controls/`:** Control group compilation for dashboard interactivity.
+- **`filters/`:** Filter compilation supporting various filter types.
+- **`queries/`:** Query compilation for KQL, Lucene, and ES|QL.
+
+**CLI Package (`packages/kb-dashboard-cli/src/dashboard_compiler/`):**
+
+- **`cli.py`:** Command-line interface for compiling dashboards and uploading to Kibana.
+- **`lsp/`:** Language Server Protocol implementation for VS Code extension.
+- **`sample_data/`:** Sample data loading utilities.
+- **`tools/`:** CLI tooling utilities.
+
+**CLI Package Tests (`packages/kb-dashboard-cli/tests/`):**
+
+- Test files including snapshot tests to verify compiler output against expected JSON.
+
+## Data Flow
+
+1. YAML file is read.
+2. YAML content is parsed into a Python dictionary.
+3. The dictionary is validated and converted into a hierarchy of Pydantic config model objects.
+4. Compile functions transform the config model hierarchy into view model objects.
+5. The compile functions are called recursively on nested objects to build the view model structure.
+6. View models are serialized to JSON using Pydantic's `model_dump_json()` method.
+7. A Kibana-compatible NDJSON file is generated.
+
+```mermaid
+graph TD
+    A[YAML File] --> B{Load & Parse YAML}
+    B --> C[Python Dictionary]
+    C --> D{Pydantic Validation}
+    D --> E[Config Model Hierarchy]
+    E --> F{Compile Functions}
+    F --> G[View Model Hierarchy]
+    G --> H{model_dump_json}
+    H --> I[Kibana JSON/NDJSON]
+
+# Dashboard Decompiling Guide: Converting Kibana JSON to YAML
+
+This guide provides instructions for converting Kibana dashboard JSON files into YAML format for kb-yaml-to-lens. It is designed to be consumed by LLMs (Large Language Models) to perform conversions efficiently.
+
+## Quick Reference
+
+**Complete Documentation**: For full schema reference and examples, use [llms-full.txt](https://strawgate.com/kb-yaml-to-lens/llms-full.txt) which contains all project documentation.
+
+**Workflow**: `kb-dashboard fetch` → `kb-dashboard disassemble` → Convert to YAML → `kb-dashboard compile` → Validate
+
+## Fetching Dashboard from Kibana
+
+Retrieve a dashboard directly from Kibana using a URL or ID:
+
+```bash
+# Using dashboard URL
+kb-dashboard fetch "https://kibana.example.com/app/dashboards#/view/my-id" \
+    --output dashboard.ndjson
+
+# Using dashboard ID
+kb-dashboard fetch my-dashboard-id --output dashboard.ndjson
+```
+
+**Input Types:**
+
+The `fetch` command accepts two types of input:
+
+1. **Dashboard URL** - Full Kibana dashboard URL (e.g., `https://kibana.example.com/app/dashboards#/view/my-id`)
+2. **Dashboard ID** - Plain dashboard ID (e.g., `my-dashboard-id`)
+
+**How it works:**
+
+- If the input looks like a URL, the dashboard ID is extracted from the URL
+- Otherwise, the input is treated as a plain dashboard ID
+
+**Authentication Options:**
+
+```bash
+# API Key authentication (recommended)
+kb-dashboard fetch my-dashboard-id --output dashboard.ndjson \
+    --kibana-api-key "your-api-key"
+
+# Username/password authentication
+kb-dashboard fetch my-dashboard-id --output dashboard.ndjson \
+    --kibana-username user --kibana-password pass
+
+# Specific Kibana space
+kb-dashboard fetch my-dashboard-id --output dashboard.ndjson \
+    --kibana-space-id "my-space"
+```
+
+**Input Formats Supported:**
+
+- **URL (standard):** `https://kibana.example.com/app/dashboards#/view/{id}`
+- **URL (with space):** `https://kibana.example.com/s/{space}/app/dashboards#/view/{id}`
+- **URL (with query params):** `https://kibana.example.com/app/dashboards#/view/{id}?_g=...`
+- **Plain dashboard ID:** `my-dashboard-id` or `dashboard-123`
+
+## Disassembly
+
+Break dashboard JSON into components:
+
+```bash
+kb-dashboard disassemble dashboard.ndjson -o output_dir/
+```
+
+**Output Structure:**
+
+```text
+output_dir/
+├── metadata.json       # Dashboard title, description, id
+├── options.json        # Display options (margins, colors, etc.)
+├── controls.json       # Dashboard controls (if present)
+├── filters.json        # Dashboard-level filters (if present)
+├── references.json     # Data view references
+└── panels/             # Individual panel JSON files
+    ├── 000_panel-1_lens.json
+    ├── 001_panel-2_markdown.json
+    └── ...
+```
+
+## Conversion Strategy
+
+### Incremental Approach
+
+Convert one panel at a time and validate after each addition:
+
+1. Create minimal dashboard structure
+2. Add first panel
+3. Compile: `kb-dashboard compile`
+4. Fix errors if any
+5. Repeat for remaining panels
+
+### Minimal YAML
+
+Omit fields that match defaults. Common defaults:
+
+**Dashboard Level:**
+
+- `use_margins: true`
+- `sync_colors: false`
+- `sync_cursor: true`
+- `sync_tooltips: false`
+- `hide_panel_titles: false`
+
+**Panel Level:**
+
+- Legend: `show: true`, `position: right`
+- Values: `show_values: false`
+- Breakdown: `size: 5`
+
+Reference the documentation in llms-full.txt for component-specific defaults.
+
+## Component Mapping
+
+### Dashboard Metadata
+
+**Input (metadata.json):**
+
+```json
+{
+  "id": "my-dashboard-id",
+  "title": "System Metrics Overview",
+  "description": "Dashboard showing system performance metrics"
+}
+```
+
+**Output (YAML):**
+
+```yaml
+---
+dashboards:
+  - name: System Metrics Overview
+    description: Dashboard showing system performance metrics
+    panels: []  # Panels will be added incrementally
+```
+
+### Markdown Panels
+
+**Input:**
+
+```json
+{
+  "type": "markdown",
+  "gridData": {"x": 0, "y": 0, "w": 48, "h": 3},
+  "panelConfig": {
+    "markdown": "# Title\n\nContent here"
+  }
+}
+```
+
+**Output:**
+
+```yaml
+- markdown:
+    content: |
+      # Title
+
+      Content here
+  size: {w: 48, h: 3}
+```
+
+### Lens Metric Panels
+
+**Input:**
+
+```json
+{
+  "type": "lens",
+  "gridData": {"x": 0, "y": 3, "w": 24, "h": 15},
+  "embeddableConfig": {
+    "attributes": {
+      "title": "Total Documents",
+      "visualizationType": "lnsMetric",
+      "state": {
+        "datasourceStates": {
+          "formBased": {
+            "layers": {
+              "layer1": {
+                "columns": {
+                  "col1": {
+                    "operationType": "count",
+                    "label": "Count"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "references": [
+        {
+          "type": "index-pattern",
+          "id": "logs-*",
+          "name": "indexpattern-datasource-layer-layer1"
+        }
+      ]
+    }
+  }
+}
+```
+
+**Output:**
+
+```yaml
+- title: Total Documents
+  size: {w: 24, h: 15}
+  position: {x: 0, y: 3}
+  lens:
+    type: metric
+    data_view: logs-*
+    primary:
+      aggregation: count
+```
+
+### Lens Pie Charts
+
+**Input:**
+
+```json
+{
+  "type": "lens",
+  "visualizationType": "lnsPie",
+  "state": {
+    "datasourceStates": {
+      "formBased": {
+        "layers": {
+          "layer1": {
+            "columns": {
+              "col1": {
+                "operationType": "terms",
+                "sourceField": "status",
+                "params": {"size": 5, "orderBy": {"type": "column", "columnId": "col2"}, "orderDirection": "desc"}
+              },
+              "col2": {
+                "operationType": "count"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Output:**
+
+```yaml
+- title: Status Breakdown
+  size: {w: 24, h: 15}
+  position: {x: 24, y: 3}
+  lens:
+    type: pie
+    data_view: logs-*
+    dimensions:
+      - field: status
+        type: values
+        size: 5
+    metrics:
+      - aggregation: count
+```
+
+### Dashboard Controls
+
+**Input (controls.json):**
+
+```json
+{
+  "panelsJSON": "[{\"type\":\"optionsListControl\",\"order\":0,\"width\":\"medium\",\"fieldName\":\"namespace\"}]",
+  "controlStyle": "oneLine"
+}
+```
+
+**Output:**
+
+```yaml
+controls:
+  - type: options
+    label: Namespace
+    data_view: metrics-*
+    field: namespace
+```
+
+Reference [Dashboard Controls](controls/config.md) for complete options.
+
+### Dashboard Filters
+
+**Input (filters.json):**
+
+```json
+[
+  {
+    "meta": {
+      "type": "phrase",
+      "key": "service.name",
+      "params": {"query": "web-server"}
+    }
+  }
+]
+```
+
+**Output:**
+Reference [Filters & Queries](filters/config.md) for filter conversion.
+
+## Panel Type Reference
+
+| Kibana Type | YAML Type | Documentation |
+| ----------- | -------------------------- | ---------------------------------------- |
+| `lnsMetric` | `lens.type: metric` | [Metric Charts](panels/metric.md) |
+| `lnsPie` | `lens.type: pie` | [Pie Charts](panels/pie.md) |
+| `lnsXY` | `lens.type: line/bar/area` | [XY Charts](panels/xy.md) |
+| `lnsGauge` | `lens.type: gauge` | [Gauge Charts](panels/gauge.md) |
+| `lnsDatatable` | `lens.type: table` | [Datatable Charts](panels/datatable.md) |
+| `markdown` | `markdown` | [Markdown Panels](panels/markdown.md) |
+| `links` | `links` | [Links Panels](panels/links.md) |
+
+For ES|QL-based panels, see [ES|QL Panels](panels/esql.md).
+
+## Validation
+
+### Compile
+
+```bash
+kb-dashboard compile --input-dir my-yaml/ --output-dir compiled/
+```
+
+### Compare Structure
+
+Use the comparison helper script to quickly check panel counts and types:
+
+```bash
+scripts/compare_panel_counts.sh original.ndjson compiled/output.ndjson
+```
+
+### Verification Workflow (Round-Trip Testing)
+
+For thorough validation, use this round-trip workflow to verify the compiled output matches the original:
+
+1. **Compile YAML to JSON:**
+
+   ```bash
+   kb-dashboard compile --input-dir my-yaml/ --output-dir /tmp/compiled/
+   ```
+
+   **IMPORTANT:** Fix any compilation errors before proceeding. The YAML must compile successfully.
+
+2. **Disassemble both original and compiled dashboards:**
+
+   ```bash
+   # Disassemble original
+   kb-dashboard disassemble original.ndjson -o /tmp/original_disassembled/
+
+   # Disassemble compiled
+   kb-dashboard disassemble /tmp/compiled/output.ndjson -o /tmp/compiled_disassembled/
+   ```
+
+3. **Compare panel structures:**
+
+   Use the comparison helper script to analyze differences:
+
+   ```bash
+   python3 scripts/compare_dashboards.py /tmp/original_disassembled /tmp/compiled_disassembled
+   ```
+
+   This will show panel counts, types, and identify any mismatches.
+
+4. **Verify panel structure and configuration:**
+
+   Use `jq` to compare specific panel configurations between original and compiled:
+
+   ```bash
+   # Compare specific panel JSON structures
+   diff -u \
+     <(jq '.embeddableConfig.attributes.state' /tmp/original_disassembled/panels/003_panel-4_lens.json) \
+     <(jq '.embeddableConfig.attributes.state' /tmp/compiled_disassembled/panels/003_panel-4_lens.json)
+   ```
+
+   **What to verify for each panel type:**
+
+   **XY Charts (line, bar, area):**
+   - Chart type matches (`seriesType` in original → `type` in YAML)
+   - Stacking mode preserved (if `yConfig[].axisMode: stacked` exists)
+   - Legend configuration matches (`legend.isVisible`, `legend.position`)
+   - Dimensions properly mapped (count columns by `isBucketed: true`)
+   - Breakdown configurations match (field names, size parameters)
+
+   **Datatables:**
+   - All bucketed columns appear as row dimensions
+   - Size parameters match for each dimension
+   - Metric columns preserve aggregation functions
+
+   **All Lens panels:**
+   - Aggregation functions match (median, average, sum, etc.)
+   - Field names are exact (including namespace prefixes)
+   - Format settings preserved (percent, bytes, number, etc.)
+
+**Understanding discrepancies:**
+
+When comparing original and compiled dashboards, some differences are expected:
+
+- ✅ **Expected (safe):** Panel IDs differ, minor query formatting, panel order variations
+- ⚠️ **Needs investigation:** Panel count mismatch, visualization type changes, missing dimensions/metrics, field name differences
+
+**Verification checklist:**
+
+Before considering a conversion complete:
+
+- [ ] YAML compiles without errors
+- [ ] Panel counts match (or differences are documented)
+- [ ] Panel types match (lens, visualization, links, markdown)
+- [ ] Chart configurations preserved (type, stacking, legends)
+- [ ] All dimensions and breakdowns accounted for
+- [ ] Size parameters match original values
+- [ ] Field names and aggregations verified
+
+## Common Patterns
+
+### Lens Operation Mapping
+
+| Kibana Operation | YAML Aggregation | Notes |
+| ---------------- | ------------------------ | --------------------------- |
+| `count` | `aggregation: count` | Document count |
+| `sum` | `aggregation: sum` | Sum of field values |
+| `avg` | `aggregation: average` | Average of field values |
+| `min` | `aggregation: min` | Minimum value |
+| `max` | `aggregation: max` | Maximum value |
+| `median` | `aggregation: median` | Median value |
+| `percentile` | `aggregation: percentile` | Requires `percentile` param |
+| `terms` | `type: values` | Used in breakdowns/slices |
+| `date_histogram` | `type: date_histogram` | Time-based dimension |
+| `range` | `type: range` | Range-based dimension |
+
+### XY Chart Dimensions
+
+**Input (Kibana lens state):**
+
+```json
+{
+  "columns": {
+    "col1": {
+      "operationType": "date_histogram",
+      "sourceField": "@timestamp",
+      "params": {"interval": "auto"}
+    },
+    "col2": {
+      "operationType": "avg",
+      "sourceField": "system.cpu.total.norm.pct"
+    }
+  }
+}
+```
+
+**Output:**
+
+```yaml
+lens:
+  type: line
+  data_view: metrics-*
+  dimensions:
+    - field: '@timestamp'
+      type: date_histogram
+  metrics:
+    - field: system.cpu.total.norm.pct
+      aggregation: average
+```
+
+### Multi-Dimension Breakdowns
+
+**Input:**
+
+```json
+{
+  "columns": {
+    "col1": {"operationType": "date_histogram", "sourceField": "@timestamp"},
+    "col2": {"operationType": "terms", "sourceField": "host.name"},
+    "col3": {"operationType": "avg", "sourceField": "cpu.usage"}
+  }
+}
+```
+
+**Output:**
+
+```yaml
+lens:
+  type: line
+  data_view: metrics-*
+  dimensions:
+    - field: '@timestamp'
+      type: date_histogram
+  breakdown:
+    - field: host.name
+      type: values
+  metrics:
+    - field: cpu.usage
+      aggregation: average
+```
+
+## Error Resolution
+
+### Schema Validation Errors
+
+```text
+ValidationError: 'type' is a required property
+```
+
+**Solution:** Check required fields in panel type documentation. Each panel type has specific required fields.
+
+### Type Errors
+
+```text
+TypeError: Expected string, got int
+```
+
+**Solution:** Verify field types match schema. Common issues:
+
+- Numbers as strings: use `100` not `"100"`
+- Booleans as strings: use `true` not `"true"`
+
+### Unsupported Panel Types
+
+```text
+Error: Panel type 'vega' is not supported
+```
+
+**Solution:** See [supported panel types](panels/base.md). For unsupported panels, either:
+
+- Create placeholder markdown panel
+- Skip the panel and document it
+
+### Reference Resolution
+
+```text
+Error: Data view reference 'logs-*' not found
+```
+
+**Solution:** Ensure data views exist in target Kibana instance or are defined in YAML.
+
+## Complete Example
+
+**Disassembled Panel (001_panel-2_lens.json):**
+
+```json
+{
+  "type": "lens",
+  "gridData": {"x": 0, "y": 3, "w": 24, "h": 15},
+  "embeddableConfig": {
+    "attributes": {
+      "title": "Total Documents",
+      "visualizationType": "lnsMetric",
+      "state": {
+        "datasourceStates": {
+          "formBased": {
+            "layers": {
+              "layer1": {
+                "columns": {
+                  "col1": {"operationType": "count", "label": "Count"}
+                }
+              }
+            }
+          }
+        }
+      },
+      "references": [{"type": "index-pattern", "id": "logs-*"}]
+    }
+  }
+}
+```
+
+**Converted YAML:**
+
+```yaml
+---
+dashboards:
+  - name: Application Monitoring
+    description: Real-time application metrics
+    panels:
+      - title: Total Documents
+        size: {w: 24, h: 15}
+        position: {x: 0, y: 3}
+        lens:
+          type: metric
+          data_view: logs-*
+          primary:
+            aggregation: count
+```
+
+**Validation:**
+
+```bash
+kb-dashboard compile
+# Success! 1 panel
+```
+
+## Additional Resources
+
+- **Complete Documentation**: [llms-full.txt](https://strawgate.com/kb-yaml-to-lens/llms-full.txt)
+- **Examples**: [Complete Examples](examples/index.md)
+- **Aerospike Examples**: [Complex real-world dashboards](examples/aerospike/overview.yaml)
+- **Panel Type Docs**: [Panel Types Overview](panels/base.md)
+- **Controls**: [Dashboard Controls](controls/config.md)
+- **Filters**: [Filters & Queries](filters/config.md)
+- **Advanced Topics**: [ES|QL Views](advanced/esql-views.md), [Color Assignments](advanced/color-assignments.md)
+


### PR DESCRIPTION
Closes #34

## What this adds

A self-contained `dashboards/` module for YAML-based Kibana dashboards compiled with [`kb-yaml-to-lens`](https://github.com/strawgate/kb-yaml-to-lens).

## Structure

```
dashboards/
├── AGENTS.md                        # Dashboard expert agent context
├── README.md                        # Quick-start and usage guide
├── scripts/
│   └── sync-skills.sh               # Pull updated docs from alvarolobato/grafana-import-cli
├── skills/                          # AI agent reference docs
│   ├── iptv-data-model.md           # IPTV index schemas — maintained in this repo
│   ├── kibana-dashboard-yaml.md     # YAML format spec (synced from upstream)
│   ├── esql-language-reference.md   # ES|QL reference (synced)
│   ├── esql-query-patterns.md       # Query patterns (synced)
│   ├── kibana-dashboard-style-guide.md  (synced)
│   └── kb-dashboard-cli-usage.md    (synced)
└── definitions/
    ├── user-dashboard.yaml          # User leaderboard, activity, recent sessions
    └── channel-dashboard.yaml       # Channel metrics, bandwidth, error rate
```

## Keeping docs up to date

Synced skill files (everything except `iptv-data-model.md`) can be refreshed from [`alvarolobato/grafana-import-cli`](https://github.com/alvarolobato/grafana-import-cli) with:

```bash
bash dashboards/scripts/sync-skills.sh
```

## Using the dashboards

```bash
# Compile (dry run)
uvx kb-dashboard-cli compile --input-file dashboards/definitions/user-dashboard.yaml

# Compile + upload
export KIBANA_URL=https://your-kibana:5601
export KIBANA_API_KEY=your-key
uvx kb-dashboard-cli compile --input-file dashboards/definitions/user-dashboard.yaml --upload
```

## Root AGENTS.md

Added a module agent table so AI agents pick up `dashboards/AGENTS.md` when working in the dashboards folder.